### PR TITLE
Refine code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - "assets/**"
+      - "examples/**"
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
This makes the Claude code review workflow not run under these conditions:
* If a PR name includes `[skip-review]` or `[WIP]`
* If a commit only changes files in the `assets/` or `examples/` directories

See also: #45