### PR TITLE
Add ALS beamline 8.3.2 (micro-CT) and xray_tomography technique

### DIFF
--- a/src/lambda_ber_schema/schema/lambda_ber_schema.yaml
+++ b/src/lambda_ber_schema/schema/lambda_ber_schema.yaml
@@ -2953,6 +2953,21 @@ enums:
           mail_in_service: "true"
         aliases:
           - BL8.3.1
+      ALS_BL832:
+        title: "ALS BL8.3.2"
+        description: >-
+          Hard X-ray micro-tomography beamline for non-destructive 3D imaging.
+          Provides high-resolution micro-CT capabilities for biological, geological,
+          and materials samples. Supports absorption and phase contrast imaging modes.
+        annotations:
+          facility: FacilityEnum:ALS
+          beamline_id: "8.3.2"
+          techniques: TechniqueEnum:xray_tomography
+          doe_beamline: "true"
+          website: "https://microct.lbl.gov/"
+        aliases:
+          - BL8.3.2
+          - microCT
       ALS_BL1222:
         title: "ALS BL12.2.2"
         description: "High-throughput macromolecular crystallography beamline"
@@ -3419,6 +3434,15 @@ enums:
         comments:
           - "Pump-probe crystallography for capturing structural dynamics"
           - "Requires fast X-ray pulses (synchrotron or XFEL)"
+      xray_tomography:
+        description: "X-ray computed tomography (micro-CT) for 3D imaging"
+        meaning: CHMO:0002743
+        exact_mappings:
+          - PaNET:01154  # tomography
+        comments:
+          - "Non-destructive 3D imaging technique"
+          - "Includes micro-CT, nano-CT, and phase contrast tomography"
+          - "Used for cellular imaging, materials science, and paleontology"
 
   ProcessingStatusEnum:
     description: "Processing status"


### PR DESCRIPTION
## Summary

- Add `xray_tomography` technique to TechniqueEnum
- Add ALS beamline 8.3.2 (micro-CT tomography) to BeamlineEnum

## Changes

### New Technique
- **`xray_tomography`**: X-ray computed tomography (micro-CT) for 3D imaging
  - CHMO meaning: CHMO:0002743
  - PaNET mapping: PaNET:01154 (tomography)
  - Supports absorption and phase contrast imaging modes

### New Beamline
- **`ALS_BL832`**: Hard X-ray micro-tomography beamline at ALS
  - Beamline ID: 8.3.2
  - Technique: xray_tomography
  - Website: https://microct.lbl.gov/
  - Aliases: BL8.3.2, microCT

## Test plan

- [x] Schema validates with `linkml-lint`
- [ ] Regenerate assets after merge with `make gen-project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)