### PR TITLE
Add SSSOM export and comprehensive mmCIF/PDB mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCDIR := ./docs
 ELEMENTSDIR := ./docs/elements
 PYDANTIC := src/lambda_ber_schema/pydantic.py
 
-all: gen-project gendoc test-examples gen-pydantic
+all: gen-project gendoc test-examples gen-pydantic gen-sssom
 test: gen-project test-examples
 
 gen-project:
@@ -22,6 +22,12 @@ test-examples:
 gendoc: $(DOCDIR)
 	cp -pr src/docs/* $(DOCDIR)
 	$(RUN) gen-doc -d $(ELEMENTSDIR) $(SCHEMA)
+
+gen-sssom: assets/sssom/lambda_ber_schema.sssom.tsv
+
+assets/sssom/lambda_ber_schema.sssom.tsv: $(SCHEMA)
+	mkdir -p assets/sssom
+	$(RUN) gen-sssom $(SCHEMA) -o $@
 
 serve:
 	$(RUN) mkdocs serve

--- a/assets/sssom/lambda_ber_schema.sssom.tsv
+++ b/assets/sssom/lambda_ber_schema.sssom.tsv
@@ -1,0 +1,267 @@
+#license: https://creativecommons.org/publicdomain/zero/1.0/
+#mapping_set_id: http://w3id.org/lambda/
+#mapping_tool: https://w3id.org/linkml/
+#creator_id: linkml_user
+#mapping_date: 2026-03-12
+#curie_map: 
+# lambda: http://w3id.org/lambda/
+# lambdaber: http://w3id.org/lambda/
+# linkml: https://w3id.org/linkml/
+# dcterms: http://purl.org/dc/terms/
+# skos: http://www.w3.org/2004/02/skos/core#
+# rdfs: http://www.w3.org/2000/01/rdf-schema#
+# prov: http://www.w3.org/ns/prov#
+# sio: http://semanticscience.org/resource/
+# nmdc: https://w3id.org/nmdc/
+# NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+# UBERON: http://purl.obolibrary.org/obo/UBERON_
+# CL: http://purl.obolibrary.org/obo/CL_
+# GO: http://purl.obolibrary.org/obo/GO_
+# nsls2: https://github.com/NSLS2/BER-LAMBDA/
+# imgCIF: https://github.com/dials/cbflib/blob/main/doc/cif_img_1.8.6.dic#
+# mmCIF: http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/
+# ROR: https://ror.org/
+# wikidata: http://www.wikidata.org/entity/
+# CHMO: http://purl.obolibrary.org/obo/CHMO_
+# pdb: https://www.rcsb.org/structure/
+# sasbdb: https://www.sasbdb.org/data/
+# simplescattering: https://www.simplescattering.com/open_dataset/
+# ispyb: https://ispyb.github.io/ISPyB/
+# PaNET: http://purl.org/pan-science/PaNET/PaNET
+# UO: http://purl.obolibrary.org/obo/UO_
+# emsl: https://api.emsl.pnnl.gov/external/
+subject_id	subject_label	predicate_id	predicate_modifier	object_id	object_label	match_type	subject_source	object_source	mapping_tool	confidence	subject_match_field	object_match_field	subject_category	object_category	match_string	comment
+lambda:ExperimentalMethodEnum#x_ray_diffraction	x_ray_diffraction	skos:exactMatch		CHMO:0000156		skos:exactMatch	http://w3id.org/lambda/						ExperimentalMethodEnum			
+lambda:FacilityEnum#NSLS_II	NSLS_II	skos:exactMatch		ROR:01q47ea17		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#ALS	ALS	skos:exactMatch		ROR:02jbv0t02		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#SSRL	SSRL	skos:exactMatch		ROR:05gzmn429		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#ESRF	ESRF	skos:exactMatch		ROR:02550n020		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#DIAMOND	DIAMOND	skos:exactMatch		ROR:05etxs293		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#PHOTON_FACTORY	PHOTON_FACTORY	skos:exactMatch		ROR:01g5y5k24		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#APS	APS	skos:exactMatch		ROR:05gvnxz63		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#SPRING8	SPRING8	skos:exactMatch		ROR:01xjv7358		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#PETRA_III	PETRA_III	skos:exactMatch		ROR:01js2sh04		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#SOLEIL	SOLEIL	skos:exactMatch		ROR:01ydb3330		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#AUSTRALIAN_SYNCHROTRON	AUSTRALIAN_SYNCHROTRON	skos:exactMatch		ROR:03vk18a84		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#EMSL	EMSL	skos:exactMatch		ROR:05h992307		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#SNS	SNS	skos:exactMatch		ROR:01qz5mb56		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:FacilityEnum#HFIR	HFIR	skos:exactMatch		ROR:01qz5mb56		skos:exactMatch	http://w3id.org/lambda/						FacilityEnum			
+lambda:InstrumentCategoryEnum#SYNCHROTRON_BEAMLINE	SYNCHROTRON_BEAMLINE	skos:exactMatch		CHMO:0001084		skos:exactMatch	http://w3id.org/lambda/						InstrumentCategoryEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#acetylation	acetylation	skos:exactMatch		GO:0006473		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#acylation	acylation	skos:exactMatch		GO:0043543		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#alkylation	alkylation	skos:exactMatch		GO:0008213		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#arginylation	arginylation	skos:exactMatch		GO:0016598		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#carbamoylation	carbamoylation	skos:exactMatch		GO:0046944		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#carboxylation	carboxylation	skos:exactMatch		GO:0018214		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#deacylation	deacylation	skos:exactMatch		GO:0035601		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#dealkylation	dealkylation	skos:exactMatch		GO:0008214		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#deamination	deamination	skos:exactMatch		GO:0018277		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#deglutathionylation	deglutathionylation	skos:exactMatch		GO:0080058		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#deglycation	deglycation	skos:exactMatch		GO:0036525		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#deglycosylation	deglycosylation	skos:exactMatch		GO:0006517		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#dephosphorylation	dephosphorylation	skos:exactMatch		GO:0006470		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#flavinylation	flavinylation	skos:exactMatch		GO:0017013		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#glutathionylation	glutathionylation	skos:exactMatch		GO:0010731		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#hydroxylation	hydroxylation	skos:exactMatch		GO:0018126		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#lipidation	lipidation	skos:exactMatch		GO:0006497		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#methylation	methylation	skos:exactMatch		GO:0006479		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#myristoylation	myristoylation	skos:exactMatch		GO:0018377		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#nitrosylation	nitrosylation	skos:exactMatch		GO:0017014		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#oxidation	oxidation	skos:exactMatch		GO:0018158		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#palmitoylation	palmitoylation	skos:exactMatch		GO:0018345		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#peptidyl_amino_acid_modification	peptidyl_amino_acid_modification	skos:exactMatch		GO:0018193		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#phosphorylation	phosphorylation	skos:exactMatch		GO:0006468		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#post_translational_protein_modification	post_translational_protein_modification	skos:exactMatch		GO:0043687		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#prenylation	prenylation	skos:exactMatch		GO:0018342		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#proteolysis	proteolysis	skos:exactMatch		GO:0006508		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#sulfation	sulfation	skos:exactMatch		GO:0006477		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#sulfhydration	sulfhydration	skos:exactMatch		GO:0044524		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#sumoylation	sumoylation	skos:exactMatch		GO:0016925		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+http://w3id.org/lambda/functional_annotation/:PTMTypeEnum#ubiquitination	ubiquitination	skos:exactMatch		GO:0016567		skos:exactMatch	http://w3id.org/lambda/functional_annotation						PTMTypeEnum			
+lambda:TechniqueEnum#cryo_em	cryo_em	skos:exactMatch		CHMO:0002413		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#xray_crystallography	xray_crystallography	skos:exactMatch		CHMO:0000156		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#saxs	saxs	skos:exactMatch		CHMO:0000204		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#waxs	waxs	skos:exactMatch		CHMO:0000207		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#sans	sans	skos:exactMatch		CHMO:0000184		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#cryo_et	cryo_et	skos:exactMatch		CHMO:0002413		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#electron_microscopy	electron_microscopy	skos:exactMatch		CHMO:0000068		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#mass_spectrometry	mass_spectrometry	skos:exactMatch		CHMO:0000470		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#xas	xas	skos:exactMatch		CHMO:0000298		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#xanes	xanes	skos:exactMatch		CHMO:0000305		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#exafs	exafs	skos:exactMatch		CHMO:0000300		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#neutron_crystallography	neutron_crystallography	skos:exactMatch		CHMO:0000182		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#fiber_diffraction	fiber_diffraction	skos:exactMatch		CHMO:0000156		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#time_resolved_crystallography	time_resolved_crystallography	skos:exactMatch		CHMO:0000156		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:TechniqueEnum#xray_tomography	xray_tomography	skos:exactMatch		CHMO:0002743		skos:exactMatch	http://w3id.org/lambda/						TechniqueEnum			
+lambda:accelerating_voltage	cryoEMInstrument__accelerating_voltage	skos:exactMatch		mmCIF:_em_imaging.accelerating_voltage		skos:exactMatch	http://w3id.org/lambda/									
+lambda:c2_aperture	cryoEMInstrument__c2_aperture	skos:exactMatch		mmCIF:_em_imaging.c2_aperture_diameter		skos:exactMatch	http://w3id.org/lambda/									
+lambda:cs	cryoEMInstrument__cs	skos:exactMatch		mmCIF:_em_imaging.nominal_cs		skos:exactMatch	http://w3id.org/lambda/									
+lambda:cs_corrector	cryoEMInstrument__cs_corrector	skos:exactMatch		mmCIF:_em_imaging.alignment_procedure		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_mode	cryoEMInstrument__detector_mode	skos:exactMatch		mmCIF:_em_image_recording.detector_mode		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_model	cryoEMInstrument__detector_model	skos:exactMatch		mmCIF:_em_image_recording.film_or_detector_model		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_technology	cryoEMInstrument__detector_technology	skos:exactMatch		mmCIF:_em_image_recording.film_or_detector_model		skos:exactMatch	http://w3id.org/lambda/									
+lambda:energy_filter_slit_width	cryoEMInstrument__energy_filter_slit_width	skos:exactMatch		mmCIF:_em_imaging.energy_filter_slit_width		skos:exactMatch	http://w3id.org/lambda/									
+lambda:imaging_mode	cryoEMInstrument__imaging_mode	skos:exactMatch		mmCIF:_em_imaging.mode		skos:exactMatch	http://w3id.org/lambda/									
+lambda:spotsize	cryoEMInstrument__spotsize	skos:exactMatch		mmCIF:_em_imaging.detector_spot_size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:blot_time	cryoEMPreparation__blot_time	skos:exactMatch		mmCIF:_em_vitrification.time_resolved_state		skos:exactMatch	http://w3id.org/lambda/									
+lambda:chamber_temperature	cryoEMPreparation__chamber_temperature	skos:exactMatch		mmCIF:_em_vitrification.chamber_temperature		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ethane_temperature	cryoEMPreparation__ethane_temperature	skos:exactMatch		mmCIF:_em_vitrification.cryogen_name		skos:exactMatch	http://w3id.org/lambda/									
+lambda:glow_discharge_applied	cryoEMPreparation__glow_discharge_applied	skos:exactMatch		mmCIF:_em_sample_support.pretreatment_type		skos:exactMatch	http://w3id.org/lambda/									
+lambda:glow_discharge_atmosphere	cryoEMPreparation__glow_discharge_atmosphere	skos:exactMatch		mmCIF:_em_sample_support.pretreatment_atmosphere		skos:exactMatch	http://w3id.org/lambda/									
+lambda:glow_discharge_pressure	cryoEMPreparation__glow_discharge_pressure	skos:exactMatch		mmCIF:_em_sample_support.pretreatment_pressure		skos:exactMatch	http://w3id.org/lambda/									
+lambda:glow_discharge_time	cryoEMPreparation__glow_discharge_time	skos:exactMatch		mmCIF:_em_sample_support.pretreatment_time		skos:exactMatch	http://w3id.org/lambda/									
+lambda:grid_material	cryoEMPreparation__grid_material	skos:exactMatch		mmCIF:_em_sample_support.grid_material		skos:exactMatch	http://w3id.org/lambda/									
+lambda:grid_type	cryoEMPreparation__grid_type	skos:exactMatch		mmCIF:_em_sample_support.grid_type		skos:exactMatch	http://w3id.org/lambda/									
+lambda:humidity_percentage	cryoEMPreparation__humidity_percentage	skos:exactMatch		mmCIF:_em_vitrification.chamber_humidity		skos:exactMatch	http://w3id.org/lambda/									
+lambda:support_film	cryoEMPreparation__support_film	skos:exactMatch		mmCIF:_em_sample_support.grid_support_film		skos:exactMatch	http://w3id.org/lambda/									
+lambda:vitrification_instrument	cryoEMPreparation__vitrification_instrument	skos:exactMatch		mmCIF:_em_vitrification.instrument		skos:exactMatch	http://w3id.org/lambda/									
+lambda:vitrification_method	cryoEMPreparation__vitrification_method	skos:exactMatch		mmCIF:_em_vitrification.method		skos:exactMatch	http://w3id.org/lambda/									
+lambda:cryo_protectant	crystallizationConditions__cryo_protectant	skos:exactMatch		nsls2:Cryo_Protectant		skos:exactMatch	http://w3id.org/lambda/									
+lambda:crystal_id	crystallizationConditions__crystal_id	skos:exactMatch		nsls2:Crystal_ID		skos:exactMatch	http://w3id.org/lambda/									
+lambda:crystal_size_um	crystallizationConditions__crystal_size_um	skos:exactMatch		nsls2:Crystal_Size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:crystallization_conditions	crystallizationConditions__crystallization_conditions	skos:exactMatch		nsls2:Conditions		skos:exactMatch	http://w3id.org/lambda/									
+lambda:crystallization_conditions	crystallizationConditions__crystallization_conditions	skos:exactMatch		mmCIF:_exptl_crystal_grow.pdbx_details		skos:exactMatch	http://w3id.org/lambda/									
+lambda:drop_volume	crystallizationConditions__drop_volume	skos:exactMatch		nsls2:Drop_Volume		skos:exactMatch	http://w3id.org/lambda/									
+lambda:method	crystallizationConditions__method	skos:exactMatch		nsls2:Method		skos:exactMatch	http://w3id.org/lambda/									
+lambda:method	crystallizationConditions__method	skos:exactMatch		mmCIF:_exptl_crystal_grow.method		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_x_px	dataCollectionStrategy__beam_center_x_px	skos:exactMatch		mmCIF:_diffrn_detector.beam_center_x		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_y_px	dataCollectionStrategy__beam_center_y_px	skos:exactMatch		mmCIF:_diffrn_detector.beam_center_y		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_distance_mm	dataCollectionStrategy__detector_distance_mm	skos:exactMatch		mmCIF:_diffrn_detector.distance		skos:exactMatch	http://w3id.org/lambda/									
+lambda:flux_photons_per_s	dataCollectionStrategy__flux_photons_per_s	skos:exactMatch		mmCIF:_diffrn_source.pdbx_flux		skos:exactMatch	http://w3id.org/lambda/									
+lambda:oscillation_per_image_deg	dataCollectionStrategy__oscillation_per_image_deg	skos:exactMatch		mmCIF:_diffrn_scan.angle_increment		skos:exactMatch	http://w3id.org/lambda/									
+lambda:pixel_size_calibrated	dataCollectionStrategy__pixel_size_calibrated	skos:exactMatch		mmCIF:_em_image_recording.calibrated_pixel_size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:temperature_k	dataCollectionStrategy__temperature_k	skos:exactMatch		mmCIF:_diffrn.ambient_temp		skos:exactMatch	http://w3id.org/lambda/									
+lambda:total_rotation_deg	dataCollectionStrategy__total_rotation_deg	skos:exactMatch		mmCIF:_diffrn_scan_axis.angle_range		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wavelength_a	dataCollectionStrategy__wavelength_a	skos:exactMatch		mmCIF:_diffrn_radiation_wavelength.wavelength		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		nsls2:Beam_xy_x		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		imgCIF:_diffrn_detector.beam_centre_x		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		mmCIF:_diffrn_detector.beam_center_x		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		ispyb:DataCollection.xBeam		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_y	experimentRun__beam_center_y	skos:exactMatch		nsls2:Beam_xy_y		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_y	experimentRun__beam_center_y	skos:exactMatch		imgCIF:_diffrn_detector.beam_centre_y		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_y	experimentRun__beam_center_y	skos:exactMatch		mmCIF:_diffrn_detector.beam_center_y		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beam_center_y	experimentRun__beam_center_y	skos:exactMatch		ispyb:DataCollection.yBeam		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beamline	experimentRun__beamline	skos:exactMatch		nsls2:Beamline		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beamline	experimentRun__beamline	skos:exactMatch		mmCIF:_diffrn_source.pdbx_synchrotron_beamline		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beamline	experimentRun__beamline	skos:exactMatch		ispyb:BLSession.beamLineName		skos:exactMatch	http://w3id.org/lambda/									
+lambda:calibrated_pixel_size	experimentRun__calibrated_pixel_size	skos:exactMatch		mmCIF:_em_image_recording.calibrated_pixel_size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:defocus_range_max	experimentRun__defocus_range_max	skos:exactMatch		mmCIF:_em_imaging.nominal_defocus_max		skos:exactMatch	http://w3id.org/lambda/									
+lambda:defocus_range_min	experimentRun__defocus_range_min	skos:exactMatch		mmCIF:_em_imaging.nominal_defocus_min		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_distance	experimentRun__detector_distance	skos:exactMatch		nsls2:Detector_distance		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_distance	experimentRun__detector_distance	skos:exactMatch		imgCIF:_diffrn_measurement.sample_detector_distance		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_distance	experimentRun__detector_distance	skos:exactMatch		mmCIF:_diffrn_detector.distance		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_distance	experimentRun__detector_distance	skos:exactMatch		ispyb:DataCollection.detectorDistance		skos:exactMatch	http://w3id.org/lambda/									
+lambda:end_time	experimentRun__end_time	skos:exactMatch		ispyb:DataCollection.endTime		skos:exactMatch	http://w3id.org/lambda/									
+lambda:exposure_time	experimentRun__exposure_time	skos:exactMatch		ispyb:DataCollection.exposureTime		skos:exactMatch	http://w3id.org/lambda/									
+lambda:exposure_time_per_frame	experimentRun__exposure_time_per_frame	skos:exactMatch		mmCIF:_em_image_recording.average_exposure_time		skos:exactMatch	http://w3id.org/lambda/									
+lambda:flux	experimentRun__flux	skos:exactMatch		ispyb:DataCollection.flux		skos:exactMatch	http://w3id.org/lambda/									
+lambda:flux_end	experimentRun__flux_end	skos:exactMatch		ispyb:DataCollection.flux_end		skos:exactMatch	http://w3id.org/lambda/									
+lambda:frames_per_movie	experimentRun__frames_per_movie	skos:exactMatch		mmCIF:_em_image_recording.num_frames_per_image		skos:exactMatch	http://w3id.org/lambda/									
+lambda:magnification	experimentRun__magnification	skos:exactMatch		mmCIF:_em_imaging.nominal_magnification		skos:exactMatch	http://w3id.org/lambda/									
+lambda:oscillation_angle	experimentRun__oscillation_angle	skos:exactMatch		nsls2:Angle_increment		skos:exactMatch	http://w3id.org/lambda/									
+lambda:oscillation_angle	experimentRun__oscillation_angle	skos:exactMatch		imgCIF:_diffrn_scan_axis.angle_increment		skos:exactMatch	http://w3id.org/lambda/									
+lambda:oscillation_angle	experimentRun__oscillation_angle	skos:exactMatch		mmCIF:_diffrn_scan.angle_increment		skos:exactMatch	http://w3id.org/lambda/									
+lambda:oscillation_angle	experimentRun__oscillation_angle	skos:exactMatch		ispyb:DataCollection.axisRange		skos:exactMatch	http://w3id.org/lambda/									
+lambda:pixel_size_x	experimentRun__pixel_size_x	skos:exactMatch		nsls2:Pixel_size_x		skos:exactMatch	http://w3id.org/lambda/									
+lambda:pixel_size_x	experimentRun__pixel_size_x	skos:exactMatch		imgCIF:_array_element_size.size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:pixel_size_y	experimentRun__pixel_size_y	skos:exactMatch		nsls2:Pixel_size_y		skos:exactMatch	http://w3id.org/lambda/									
+lambda:pixel_size_y	experimentRun__pixel_size_y	skos:exactMatch		imgCIF:_array_element_size.size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution	experimentRun__resolution	skos:exactMatch		ispyb:DataCollection.resolution		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_at_corner	experimentRun__resolution_at_corner	skos:exactMatch		ispyb:DataCollection.resolutionAtCorner		skos:exactMatch	http://w3id.org/lambda/									
+lambda:slit_gap_horizontal	experimentRun__slit_gap_horizontal	skos:exactMatch		ispyb:DataCollection.slitGapHorizontal		skos:exactMatch	http://w3id.org/lambda/									
+lambda:slit_gap_vertical	experimentRun__slit_gap_vertical	skos:exactMatch		ispyb:DataCollection.slitGapVertical		skos:exactMatch	http://w3id.org/lambda/									
+lambda:start_angle	experimentRun__start_angle	skos:exactMatch		nsls2:Start_angle		skos:exactMatch	http://w3id.org/lambda/									
+lambda:start_angle	experimentRun__start_angle	skos:exactMatch		imgCIF:_diffrn_scan_axis.angle_start		skos:exactMatch	http://w3id.org/lambda/									
+lambda:start_angle	experimentRun__start_angle	skos:exactMatch		ispyb:DataCollection.axisStart		skos:exactMatch	http://w3id.org/lambda/									
+lambda:start_time	experimentRun__start_time	skos:exactMatch		ispyb:DataCollection.startTime		skos:exactMatch	http://w3id.org/lambda/									
+lambda:synchrotron_mode	experimentRun__synchrotron_mode	skos:exactMatch		ispyb:DataCollection.synchrotronMode		skos:exactMatch	http://w3id.org/lambda/									
+lambda:total_dose	experimentRun__total_dose	skos:exactMatch		mmCIF:_em_image_recording.avg_electron_dose_per_image		skos:exactMatch	http://w3id.org/lambda/									
+lambda:total_rotation	experimentRun__total_rotation	skos:exactMatch		nsls2:Total_rotation_deg		skos:exactMatch	http://w3id.org/lambda/									
+lambda:total_rotation	experimentRun__total_rotation	skos:exactMatch		imgCIF:_diffrn_scan_axis.angle_range		skos:exactMatch	http://w3id.org/lambda/									
+lambda:transmission	experimentRun__transmission	skos:exactMatch		ispyb:DataCollection.transmission		skos:exactMatch	http://w3id.org/lambda/									
+lambda:undulator_gap	experimentRun__undulator_gap	skos:exactMatch		ispyb:DataCollection.undulatorGap1		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wavelength	experimentRun__wavelength	skos:exactMatch		nsls2:Wavelength		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wavelength	experimentRun__wavelength	skos:exactMatch		imgCIF:_diffrn_radiation_wavelength.wavelength		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wavelength	experimentRun__wavelength	skos:exactMatch		mmCIF:_diffrn_radiation_wavelength.wavelength		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wavelength	experimentRun__wavelength	skos:exactMatch		ispyb:DataCollection.wavelength		skos:exactMatch	http://w3id.org/lambda/									
+lambda:beamline_id	instrument__beamline_id	skos:exactMatch		mmCIF:_diffrn_source.pdbx_synchrotron_beamline		skos:exactMatch	http://w3id.org/lambda/									
+lambda:anom_corr	qualityMetrics__anom_corr	skos:exactMatch		mmCIF:_reflns.pdbx_CC_half_anomalous		skos:exactMatch	http://w3id.org/lambda/									
+lambda:average_b_factor_a2	qualityMetrics__average_b_factor_a2	skos:exactMatch		mmCIF:_refine.B_iso_mean		skos:exactMatch	http://w3id.org/lambda/									
+lambda:cc_half	qualityMetrics__cc_half	skos:exactMatch		mmCIF:_reflns.pdbx_CC_half		skos:exactMatch	http://w3id.org/lambda/									
+lambda:clashscore	qualityMetrics__clashscore	skos:exactMatch		mmCIF:_pdbx_struct_quality.clashscore		skos:exactMatch	http://w3id.org/lambda/									
+lambda:multiplicity	qualityMetrics__multiplicity	skos:exactMatch		mmCIF:_reflns.pdbx_redundancy		skos:exactMatch	http://w3id.org/lambda/									
+lambda:r_free	qualityMetrics__r_free	skos:exactMatch		mmCIF:_refine.ls_R_factor_R_free		skos:exactMatch	http://w3id.org/lambda/									
+lambda:r_merge	qualityMetrics__r_merge	skos:exactMatch		mmCIF:_reflns.pdbx_Rmerge_I_obs		skos:exactMatch	http://w3id.org/lambda/									
+lambda:r_pim	qualityMetrics__r_pim	skos:exactMatch		mmCIF:_reflns.pdbx_Rpim_I_all		skos:exactMatch	http://w3id.org/lambda/									
+lambda:r_work	qualityMetrics__r_work	skos:exactMatch		mmCIF:_refine.ls_R_factor_R_work		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ramachandran_favored_percent	qualityMetrics__ramachandran_favored_percent	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_favored		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ramachandran_outliers_percent	qualityMetrics__ramachandran_outliers_percent	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_outliers		skos:exactMatch	http://w3id.org/lambda/									
+lambda:space_group	qualityMetrics__space_group	skos:exactMatch		mmCIF:_symmetry.space_group_name_H-M		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_a	qualityMetrics__unit_cell_a	skos:exactMatch		mmCIF:_cell.length_a		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_alpha	qualityMetrics__unit_cell_alpha	skos:exactMatch		mmCIF:_cell.angle_alpha		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_b	qualityMetrics__unit_cell_b	skos:exactMatch		mmCIF:_cell.length_b		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_beta	qualityMetrics__unit_cell_beta	skos:exactMatch		mmCIF:_cell.angle_beta		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_c	qualityMetrics__unit_cell_c	skos:exactMatch		mmCIF:_cell.length_c		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_gamma	qualityMetrics__unit_cell_gamma	skos:exactMatch		mmCIF:_cell.angle_gamma		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wilson_b_factor_a2	qualityMetrics__wilson_b_factor_a2	skos:exactMatch		mmCIF:_reflns.B_iso_Wilson_estimate		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_0_143	refinementParameters__resolution_0_143	skos:exactMatch		mmCIF:_em_3d_reconstruction.resolution		skos:exactMatch	http://w3id.org/lambda/									
+lambda:symmetry	refinementParameters__symmetry	skos:exactMatch		mmCIF:_em_3d_reconstruction.symmetry_type		skos:exactMatch	http://w3id.org/lambda/									
+lambda:construct	sample__construct	skos:exactMatch		nsls2:Construct		skos:exactMatch	http://w3id.org/lambda/									
+lambda:expression_system	sample__expression_system	skos:exactMatch		nsls2:Expression_System		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ligand	sample__ligand	skos:exactMatch		nsls2:Ligand		skos:exactMatch	http://w3id.org/lambda/									
+lambda:molecular_weight	sample__molecular_weight	skos:exactMatch		mmCIF:_entity.formula_weight		skos:exactMatch	http://w3id.org/lambda/									
+lambda:mutations	sample__mutations	skos:exactMatch		nsls2:Mutations		skos:exactMatch	http://w3id.org/lambda/									
+lambda:protein_name	sample__protein_name	skos:exactMatch		nsls2:Protein_Name		skos:exactMatch	http://w3id.org/lambda/									
+lambda:tag	sample__tag	skos:exactMatch		nsls2:Tag		skos:exactMatch	http://w3id.org/lambda/									
+lambda:anomalous_completeness	workflowRun__anomalous_completeness	skos:exactMatch		ispyb:AutoProcScalingStatistics.anomalousCompleteness		skos:exactMatch	http://w3id.org/lambda/									
+lambda:completeness_percent	workflowRun__completeness_percent	skos:exactMatch		nsls2:Completeness		skos:exactMatch	http://w3id.org/lambda/									
+lambda:completeness_percent	workflowRun__completeness_percent	skos:exactMatch		mmCIF:_reflns.percent_possible_obs		skos:exactMatch	http://w3id.org/lambda/									
+lambda:completeness_percent	workflowRun__completeness_percent	skos:exactMatch		ispyb:AutoProcScalingStatistics.completeness		skos:exactMatch	http://w3id.org/lambda/									
+lambda:n_total_observations	workflowRun__n_total_observations	skos:exactMatch		mmCIF:_reflns.number_all		skos:exactMatch	http://w3id.org/lambda/									
+lambda:n_total_unique	workflowRun__n_total_unique	skos:exactMatch		mmCIF:_reflns.number_obs		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ramachandran_favored	workflowRun__ramachandran_favored	skos:exactMatch		nsls2:Ramachandran_Favored		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ramachandran_favored	workflowRun__ramachandran_favored	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_favored		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ramachandran_outliers	workflowRun__ramachandran_outliers	skos:exactMatch		nsls2:Ramachandran_Outliers		skos:exactMatch	http://w3id.org/lambda/									
+lambda:ramachandran_outliers	workflowRun__ramachandran_outliers	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_outliers		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_high	workflowRun__resolution_high	skos:exactMatch		nsls2:Resolution_High_A		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_high	workflowRun__resolution_high	skos:exactMatch		mmCIF:_reflns.d_resolution_high		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_high	workflowRun__resolution_high	skos:exactMatch		ispyb:AutoProcScalingStatistics.resolutionLimitHigh		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_low	workflowRun__resolution_low	skos:exactMatch		nsls2:Resolution_Low_A		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_low	workflowRun__resolution_low	skos:exactMatch		mmCIF:_reflns.d_resolution_low		skos:exactMatch	http://w3id.org/lambda/									
+lambda:resolution_low	workflowRun__resolution_low	skos:exactMatch		ispyb:AutoProcScalingStatistics.resolutionLimitLow		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rfree	workflowRun__rfree	skos:exactMatch		mmCIF:_refine.ls_R_factor_R_free		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rmsd_angles	workflowRun__rmsd_angles	skos:exactMatch		nsls2:RMSD_angles		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rmsd_angles	workflowRun__rmsd_angles	skos:exactMatch		mmCIF:_refine.pdbx_ls_sigma_I		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rmsd_bonds	workflowRun__rmsd_bonds	skos:exactMatch		nsls2:RMSD_bonds		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rmsd_bonds	workflowRun__rmsd_bonds	skos:exactMatch		mmCIF:_refine.pdbx_ls_sigma_F		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rwork	workflowRun__rwork	skos:exactMatch		mmCIF:_refine.ls_R_factor_R_work		skos:exactMatch	http://w3id.org/lambda/									
+lambda:space_group	workflowRun__space_group	skos:exactMatch		nsls2:Space_Group		skos:exactMatch	http://w3id.org/lambda/									
+lambda:space_group	workflowRun__space_group	skos:exactMatch		mmCIF:_symmetry.space_group_name_H-M		skos:exactMatch	http://w3id.org/lambda/									
+lambda:space_group	workflowRun__space_group	skos:exactMatch		ispyb:AutoProcScaling.spaceGroup		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_a	workflowRun__unit_cell_a	skos:exactMatch		nsls2:Unit_Cell_a		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_a	workflowRun__unit_cell_a	skos:exactMatch		mmCIF:_cell.length_a		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_alpha	workflowRun__unit_cell_alpha	skos:exactMatch		nsls2:Unit_Cell_alpha		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_alpha	workflowRun__unit_cell_alpha	skos:exactMatch		mmCIF:_cell.angle_alpha		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_b	workflowRun__unit_cell_b	skos:exactMatch		nsls2:Unit_Cell_b		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_b	workflowRun__unit_cell_b	skos:exactMatch		mmCIF:_cell.length_b		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_beta	workflowRun__unit_cell_beta	skos:exactMatch		nsls2:Unit_Cell_beta		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_beta	workflowRun__unit_cell_beta	skos:exactMatch		mmCIF:_cell.angle_beta		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_c	workflowRun__unit_cell_c	skos:exactMatch		nsls2:Unit_Cell_c		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_c	workflowRun__unit_cell_c	skos:exactMatch		mmCIF:_cell.length_c		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_gamma	workflowRun__unit_cell_gamma	skos:exactMatch		nsls2:Unit_Cell_gamma		skos:exactMatch	http://w3id.org/lambda/									
+lambda:unit_cell_gamma	workflowRun__unit_cell_gamma	skos:exactMatch		mmCIF:_cell.angle_gamma		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wilson_b_factor	workflowRun__wilson_b_factor	skos:exactMatch		nsls2:Wilson_B		skos:exactMatch	http://w3id.org/lambda/									
+lambda:wilson_b_factor	workflowRun__wilson_b_factor	skos:exactMatch		mmCIF:_reflns.B_iso_Wilson_estimate		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_manufacturer	xRayInstrument__detector_manufacturer	skos:exactMatch		mmCIF:_diffrn_detector.detector		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_model	xRayInstrument__detector_model	skos:exactMatch		mmCIF:_diffrn_detector.pdbx_detector_model		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_technology	xRayInstrument__detector_technology	skos:exactMatch		nsls2:Detector		skos:exactMatch	http://w3id.org/lambda/									
+lambda:detector_technology	xRayInstrument__detector_technology	skos:exactMatch		mmCIF:_diffrn_detector.type		skos:exactMatch	http://w3id.org/lambda/									
+lambda:flux_density	xRayInstrument__flux_density	skos:exactMatch		mmCIF:_diffrn_source.pdbx_flux		skos:exactMatch	http://w3id.org/lambda/									
+lambda:goniometer_type	xRayInstrument__goniometer_type	skos:exactMatch		mmCIF:_diffrn_measurement.device		skos:exactMatch	http://w3id.org/lambda/									
+lambda:monochromator_type	xRayInstrument__monochromator_type	skos:exactMatch		mmCIF:_diffrn_source.monochromator		skos:exactMatch	http://w3id.org/lambda/									
+lambda:source_type	xRayInstrument__source_type	skos:exactMatch		mmCIF:_diffrn_source.source		skos:exactMatch	http://w3id.org/lambda/									
+lambda:crystallization_method	xRayPreparation__crystallization_method	skos:exactMatch		mmCIF:_exptl_crystal_grow.method		skos:exactMatch	http://w3id.org/lambda/									
+lambda:loop_size	xRayPreparation__loop_size	skos:exactMatch		nsls2:Loop_Size		skos:exactMatch	http://w3id.org/lambda/									
+lambda:mounting_method	xRayPreparation__mounting_method	skos:exactMatch		nsls2:Mount_Type		skos:exactMatch	http://w3id.org/lambda/									
+lambda:mounting_temperature	xRayPreparation__mounting_temperature	skos:exactMatch		nsls2:Temperature		skos:exactMatch	http://w3id.org/lambda/									
+lambda:temperature_c	xRayPreparation__temperature_c	skos:exactMatch		mmCIF:_exptl_crystal_grow.temp		skos:exactMatch	http://w3id.org/lambda/									

--- a/src/lambda_ber_schema/schema/lambda_ber_schema.yaml
+++ b/src/lambda_ber_schema/schema/lambda_ber_schema.yaml
@@ -1,6 +1,6 @@
 id: http://w3id.org/lambda/
 name: lambda-ber-schema
-version: "0.1.2.post32.dev0+2ad9ef5" # Managed by uv-dynamic-versioning
+version: "0.1.2.post123.dev0+b316f8a" # Managed by uv-dynamic-versioning
 description: |
   lambda-ber-schema is a comprehensive schema for representing multimodal structural biology imaging data, 
   from atomic-resolution structures to tissue-level organization. It supports diverse experimental 
@@ -300,6 +300,8 @@ classes:
         description: "Molecular weight, typically specified in kilodaltons (kDa). Data providers may specify alternative units (e.g., Daltons, g/mol) by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_entity.formula_weight
       concentration:
         description: "Sample concentration, typically specified in mg/mL or µM. Data providers may specify alternative units (e.g., molar, g/L) by including the unit in the QuantityValue."
         range: QuantityValue
@@ -383,39 +385,33 @@ classes:
       protein_name:
         description: "Name of the protein"
         range: string
-        slot_uri: nsls2:Protein_Name
-        comments:
-          - "Maps to NSLS2 spreadsheet: Protein_Name"
+        exact_mappings:
+          - nsls2:Protein_Name
       construct:
         description: "Construct description (e.g., domain boundaries, truncations)"
         range: string
-        slot_uri: nsls2:Construct
-        comments:
-          - "Maps to NSLS2 spreadsheet: Construct"
+        exact_mappings:
+          - nsls2:Construct
       tag:
         description: "Affinity tag (e.g., His6, GST, MBP)"
         range: string
-        slot_uri: nsls2:Tag
-        comments:
-          - "Maps to NSLS2 spreadsheet: Tag"
+        exact_mappings:
+          - nsls2:Tag
       mutations:
         description: "Mutations present in the sample"
         range: string
-        slot_uri: nsls2:Mutations
-        comments:
-          - "Maps to NSLS2 spreadsheet: Mutations"
+        exact_mappings:
+          - nsls2:Mutations
       expression_system:
         description: "Expression system used"
         range: string
-        slot_uri: nsls2:Expression_System
-        comments:
-          - "Maps to NSLS2 spreadsheet: Expression_System"
+        exact_mappings:
+          - nsls2:Expression_System
       ligand:
         description: "Ligand or small molecule bound to sample"
         range: string
-        slot_uri: nsls2:Ligand
-        comments:
-          - "Maps to NSLS2 spreadsheet: Ligand"
+        exact_mappings:
+          - nsls2:Ligand
       oligomeric_state:
         description: "Oligomeric state of the sample (e.g., monomer, dimer, tetramer, hexamer)"
         range: string
@@ -619,7 +615,8 @@ classes:
       beamline_id:
         description: "Beamline identifier at synchrotron/neutron facility"
         range: string
-        slot_uri: mmCIF:_diffrn_source.pdbx_synchrotron_beamline
+        exact_mappings:
+          - mmCIF:_diffrn_source.pdbx_synchrotron_beamline
         comments:
           - "Use facility-specific naming convention"
           - "Examples: '12.3.1' (ALS), '17-ID-1' (NSLS-II), 'I04' (Diamond)"
@@ -642,15 +639,21 @@ classes:
         description: "Accelerating voltage in kV"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.accelerating_voltage
       cs_corrector:
         description: "Spherical aberration corrector present"
         range: boolean
+        exact_mappings:
+          - mmCIF:_em_imaging.alignment_procedure
       phase_plate:
         description: "Phase plate available"
         range: boolean
       detector_technology:
         description: "Generic detector technology type"
         range: DetectorTechnologyEnum
+        exact_mappings:
+          - mmCIF:_em_image_recording.film_or_detector_model
         comments:
           - "Use this for technology classification (e.g., direct_electron_detector, ccd)"
           - "See detector_manufacturer and detector_model for specific equipment details"
@@ -662,11 +665,15 @@ classes:
       detector_model:
         description: "Detector model (e.g., K3, Falcon 4i, DE-64)"
         range: string
+        exact_mappings:
+          - mmCIF:_em_image_recording.film_or_detector_model
         comments:
           - "Examples: K3 BioQuantum, Falcon 4i, DE-64"
       detector_mode:
         description: "Supported or default detector operating mode"
         range: DetectorModeEnum
+        exact_mappings:
+          - mmCIF:_em_image_recording.detector_mode
         comments:
           - "Indicates operating mode capabilities (e.g., counting, super_resolution)"
       detector_position:
@@ -687,10 +694,14 @@ classes:
         description: "Spherical aberration (Cs) in millimeters"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.nominal_cs
       c2_aperture:
         description: "C2 aperture size in micrometers"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.c2_aperture_diameter
       objective_aperture:
         description: "Objective aperture size in micrometers"
         range: QuantityValue
@@ -711,6 +722,8 @@ classes:
         description: "Energy filter slit width in eV"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.energy_filter_slit_width
       pixel_size_physical:
         description: "Physical pixel size in micrometers"
         range: QuantityValue
@@ -725,6 +738,8 @@ classes:
         description: "Electron beam spot size setting"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.detector_spot_size
       gunlens:
         description: "Gun lens setting"
         range: QuantityValue
@@ -732,6 +747,8 @@ classes:
       imaging_mode:
         description: "Imaging mode for electron microscopy"
         range: ImagingModeEnum
+        exact_mappings:
+          - mmCIF:_em_imaging.mode
       tem_beam_diameter:
         description: "TEM beam diameter in micrometers"
         range: QuantityValue
@@ -744,23 +761,29 @@ classes:
       source_type:
         description: "Type of X-ray source"
         range: XRaySourceTypeEnum
+        exact_mappings:
+          - mmCIF:_diffrn_source.source
       detector_technology:
         description: "Generic detector technology type"
         range: DetectorTechnologyEnum
-        slot_uri: nsls2:Detector
+        exact_mappings:
+          - nsls2:Detector
+          - mmCIF:_diffrn_detector.type
         comments:
           - "Use this for technology classification (e.g., hybrid_photon_counting, ccd)"
-          - "Maps to CBF: Detector (may contain model name)"
-          - "Maps to PDB: _diffrn_detector.type"
           - "See detector_manufacturer and detector_model for specific equipment details"
       detector_manufacturer:
         description: "Detector manufacturer (e.g., Dectris, Bruker, Rigaku, Rayonix)"
         range: string
+        exact_mappings:
+          - mmCIF:_diffrn_detector.detector
         comments:
           - "Examples: Dectris, Bruker, Rigaku, Rayonix, ADSC, MAR Research"
       detector_model:
         description: "Detector model (e.g., EIGER2 X 16M, PILATUS3 X 6M, PHOTON III)"
         range: string
+        exact_mappings:
+          - mmCIF:_diffrn_detector.pdbx_detector_model
         comments:
           - "Examples: EIGER2 X 16M, PILATUS3 X 6M, PHOTON III, HyPix-6000HE"
       energy_min:
@@ -783,10 +806,16 @@ classes:
         description: "Photon flux density in photons/s/mm²"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_source.pdbx_flux
       monochromator_type:
         description: "Type of monochromator"
+        exact_mappings:
+          - mmCIF:_diffrn_source.monochromator
       goniometer_type:
         description: "Type of goniometer"
+        exact_mappings:
+          - mmCIF:_diffrn_measurement.device
       crystal_cooling_capability:
         description: "Crystal cooling system available"
         range: boolean
@@ -915,10 +944,14 @@ classes:
         description: "Magnification used during data collection"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.nominal_magnification
       calibrated_pixel_size:
         description: "Calibrated pixel size in Angstroms per pixel"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_image_recording.calibrated_pixel_size
       camera_binning:
         description: "Camera binning factor. This must be a positive float value (e.g., 1, 1.5, 2, 3)."
         range: QuantityValue
@@ -927,10 +960,14 @@ classes:
         description: "Exposure time per frame in milliseconds"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_image_recording.average_exposure_time
       frames_per_movie:
         description: "Number of frames per movie"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_image_recording.num_frames_per_image
       total_exposure_time:
         description: "Total exposure time in milliseconds"
         range: QuantityValue
@@ -939,6 +976,8 @@ classes:
         description: "Total electron dose in e-/Angstrom^2"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_image_recording.avg_electron_dose_per_image
       dose_rate:
         description: "Dose rate in e-/pixel/s or e-/Angstrom^2/s"
         range: QuantityValue
@@ -951,10 +990,14 @@ classes:
         description: "Minimum defocus range in micrometers"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.nominal_defocus_min
       defocus_range_max:
         description: "Maximum defocus range in micrometers"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_imaging.nominal_defocus_max
       defocus_range_increment:
         description: "Defocus range increment in micrometers"
         range: QuantityValue
@@ -1363,10 +1406,14 @@ classes:
         description: "Total number of observations (before merging)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.number_all
       n_total_unique:
         description: "Total number of unique reflections"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.number_obs
       # ISPyB cross-reference IDs for workflow
       ispyb_auto_proc_program_id:
         description: "ISPyB AutoProcProgram.autoProcProgramId"
@@ -1381,38 +1428,42 @@ classes:
         description: "Refinement R-factor (working set)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_refine.ls_R_factor_R_work
       rfree:
         description: "R-free (test set)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_refine.ls_R_factor_R_free
       rmsd_bonds:
         description: "RMSD from ideal bond lengths, typically specified in Angstroms (Å). Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
         exact_mappings:
           - "nsls2:RMSD_bonds"
-          - "mmCIF:_refine.ls_d_res_high"
+          - "mmCIF:_refine.pdbx_ls_sigma_F"
       rmsd_angles:
         description: "RMSD from ideal bond angles, typically specified in degrees. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
         exact_mappings:
           - "nsls2:RMSD_angles"
-          - "mmCIF:_refine.ls_d_res_low"
+          - "mmCIF:_refine.pdbx_ls_sigma_I"
       ramachandran_favored:
         description: "Percentage of residues in favored Ramachandran regions (0-100). Data providers may specify as a decimal fraction or percentage by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
         exact_mappings:
           - "nsls2:Ramachandran_Favored"
-          - "mmCIF:_refine.pdbx_overall_ESU_R"
+          - "mmCIF:_pdbx_struct_quality.ramachandran_favored"
       ramachandran_outliers:
         description: "Percentage of Ramachandran outliers (0-100). Data providers may specify as a decimal fraction or percentage by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
         exact_mappings:
           - "nsls2:Ramachandran_Outliers"
-          - "mmCIF:_refine.pdbx_overall_ESU_R_Free"
+          - "mmCIF:_pdbx_struct_quality.ramachandran_outliers"
       clashscore:
         description: "MolProbity clashscore"
         range: QuantityValue
@@ -1861,9 +1912,13 @@ classes:
       grid_type:
         description: "Type of EM grid used"
         range: GridTypeEnum
+        exact_mappings:
+          - mmCIF:_em_sample_support.grid_type
       support_film:
         description: "Support film type"
         range: string
+        exact_mappings:
+          - mmCIF:_em_sample_support.grid_support_film
       hole_size:
         description: "Hole size, typically specified in micrometers (range: 0.5-5.0). Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
@@ -1871,10 +1926,14 @@ classes:
       vitrification_method:
         description: "Method used for vitrification"
         range: VitrificationMethodEnum
+        exact_mappings:
+          - mmCIF:_em_vitrification.method
       blot_time:
         description: "Blotting time, typically specified in seconds (range: 0.5-10.0). Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_vitrification.time_resolved_state
       blot_force:
         description: "Blotting force setting"
         range: QuantityValue
@@ -1883,21 +1942,31 @@ classes:
         description: "Chamber humidity during vitrification (range: 0-100), typically specified as a percentage. Data providers may specify as decimal fraction by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_vitrification.chamber_humidity
       chamber_temperature:
         description: "Chamber temperature, typically specified in degrees Celsius. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_vitrification.chamber_temperature
       # Additional detailed vitrification parameters from PNNL schema
       grid_material:
         description: "Grid material"
         range: GridMaterialEnum
+        exact_mappings:
+          - mmCIF:_em_sample_support.grid_material
       glow_discharge_applied:
         description: "Whether glow discharge treatment was applied"
         range: boolean
+        exact_mappings:
+          - mmCIF:_em_sample_support.pretreatment_type
       glow_discharge_time:
         description: "Glow discharge time, typically specified in seconds. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_sample_support.pretreatment_time
       glow_discharge_current:
         description: "Glow discharge current, typically specified in milliamperes. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
@@ -1905,13 +1974,19 @@ classes:
       glow_discharge_atmosphere:
         description: "Glow discharge atmosphere (air, amylamine)"
         range: string
+        exact_mappings:
+          - mmCIF:_em_sample_support.pretreatment_atmosphere
       glow_discharge_pressure:
         description: "Glow discharge pressure, typically specified in millibars. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_sample_support.pretreatment_pressure
       vitrification_instrument:
         description: "Vitrification instrument used (e.g., Vitrobot)"
         range: string
+        exact_mappings:
+          - mmCIF:_em_vitrification.instrument
       blot_number:
         description: "Number of blots applied"
         range: QuantityValue
@@ -1936,6 +2011,8 @@ classes:
         description: "Ethane temperature, typically specified in degrees Celsius. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_vitrification.cryogen_name
       plasma_treatment:
         description: "Plasma treatment details"
 
@@ -1946,22 +2023,21 @@ classes:
       method:
         description: "Crystallization method used"
         range: CrystallizationMethodEnum
-        slot_uri: nsls2:Method
-        comments:
-          - "Maps to NSLS2 spreadsheet: Method"
+        exact_mappings:
+          - nsls2:Method
+          - mmCIF:_exptl_crystal_grow.method
       crystallization_conditions:
         description: "Complete description of crystallization conditions including precipitant, pH, salts"
         range: string
-        slot_uri: nsls2:Conditions
-        comments:
-          - "Maps to NSLS2 spreadsheet: Conditions"
+        exact_mappings:
+          - nsls2:Conditions
+          - mmCIF:_exptl_crystal_grow.pdbx_details
       drop_volume:
         description: "Total drop volume, typically specified in nanoliters. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
-        slot_uri: nsls2:Drop_Volume
-        comments:
-          - "Maps to NSLS2 spreadsheet: Drop_Volume"
+        exact_mappings:
+          - nsls2:Drop_Volume
       protein_concentration:
         description: "Protein concentration for crystallization in mg/mL"
         range: QuantityValue
@@ -1969,21 +2045,18 @@ classes:
       crystal_size_um:
         description: "Crystal dimensions in micrometers (length x width x height)"
         range: string
-        slot_uri: nsls2:Crystal_Size
-        comments:
-          - "Maps to NSLS2 spreadsheet: Crystal_Size"
+        exact_mappings:
+          - nsls2:Crystal_Size
       cryo_protectant:
         description: "Cryoprotectant used for crystal cooling"
         range: string
-        slot_uri: nsls2:Cryo_Protectant
-        comments:
-          - "Maps to NSLS2 spreadsheet: Cryo_Protectant"
+        exact_mappings:
+          - nsls2:Cryo_Protectant
       crystal_id:
         description: "Identifier for the specific crystal used"
         range: string
-        slot_uri: nsls2:Crystal_ID
-        comments:
-          - "Maps to NSLS2 spreadsheet: Crystal_ID"
+        exact_mappings:
+          - nsls2:Crystal_ID
       screen_name:
         description: "Name of crystallization screen used"
       temperature_c:
@@ -2018,6 +2091,8 @@ classes:
       crystallization_method:
         description: "Method used for crystallization"
         range: CrystallizationMethodEnum
+        exact_mappings:
+          - mmCIF:_exptl_crystal_grow.method
       crystallization_conditions:
         description: "Detailed crystallization conditions"
         range: CrystallizationConditions
@@ -2027,6 +2102,8 @@ classes:
         description: "Crystallization temperature, typically specified in degrees Celsius. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_exptl_crystal_grow.temp
       drop_ratio_protein_to_reservoir:
         description: "Ratio of protein to reservoir solution in drop (e.g., 1:1, 2:1)"
       drop_volume_nl:
@@ -2064,9 +2141,8 @@ classes:
         description: "Conditions for crystal soaking"
       mounting_method:
         description: "Crystal mounting method"
-        slot_uri: nsls2:Mount_Type
-        comments:
-          - "Maps to NSLS2 spreadsheet: Mount_Type"
+        exact_mappings:
+          - nsls2:Mount_Type
       flash_cooling_method:
         description: "Flash cooling protocol"
       crystal_notes:
@@ -2076,16 +2152,14 @@ classes:
         description: "Loop size, typically specified in micrometers. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
-        slot_uri: nsls2:Loop_Size
-        comments:
-          - "Maps to NSLS2 spreadsheet: Loop_Size"
+        exact_mappings:
+          - nsls2:Loop_Size
       mounting_temperature:
         description: "Temperature during mounting, typically specified in Kelvin. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
-        slot_uri: nsls2:Temperature
-        comments:
-          - "Maps to NSLS2 spreadsheet: Temperature"
+        exact_mappings:
+          - nsls2:Temperature
 
   SAXSPreparation:
     is_a: TechniqueSpecificPreparation
@@ -2161,6 +2235,8 @@ classes:
         description: "X-ray wavelength, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_radiation_wavelength.wavelength
       detector_mode:
         description: "Detector operating mode used during this experiment"
         range: DetectorModeEnum
@@ -2171,6 +2247,8 @@ classes:
         description: "Calibrated pixel size for this experiment, typically specified in Angstroms (Å) per pixel. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_image_recording.calibrated_pixel_size
         comments:
           - "For cryo-EM: depends on magnification (Å/pixel)"
           - "For X-ray: typically mm/pixel or µm/pixel"
@@ -2179,14 +2257,20 @@ classes:
         description: "Detector distance, typically specified in millimeters. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_detector.distance
       beam_center_x_px:
         description: "Beam center X coordinate in pixels"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_detector.beam_center_x
       beam_center_y_px:
         description: "Beam center Y coordinate in pixels"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_detector.beam_center_y
       beam_size_um:
         description: "Beam size, typically specified in micrometers. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
@@ -2195,6 +2279,8 @@ classes:
         description: "Photon flux, typically specified in photons per second. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_source.pdbx_flux
       transmission_percent:
         description: "Beam transmission, typically specified as a percentage (0-100). Data providers may specify as decimal fraction by including the unit in the QuantityValue."
         range: QuantityValue
@@ -2205,14 +2291,20 @@ classes:
         description: "Data collection temperature, typically specified in Kelvin. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn.ambient_temp
       oscillation_per_image_deg:
         description: "Oscillation angle per image, typically specified in degrees. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_scan.angle_increment
       total_rotation_deg:
         description: "Total rotation range, typically specified in degrees. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_diffrn_scan_axis.angle_range
       strategy_notes:
         description: "Notes about data collection strategy"
 
@@ -2252,50 +2344,74 @@ classes:
       # Crystallographic processing metrics
       space_group:
         description: "Crystallographic space group"
+        exact_mappings:
+          - mmCIF:_symmetry.space_group_name_H-M
       unit_cell_a:
         description: "Unit cell parameter a, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_cell.length_a
       unit_cell_b:
         description: "Unit cell parameter b, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_cell.length_b
       unit_cell_c:
         description: "Unit cell parameter c, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_cell.length_c
       unit_cell_alpha:
         description: "Unit cell angle alpha, typically specified in degrees. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_cell.angle_alpha
       unit_cell_beta:
         description: "Unit cell angle beta, typically specified in degrees. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_cell.angle_beta
       unit_cell_gamma:
         description: "Unit cell angle gamma, typically specified in degrees. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_cell.angle_gamma
       multiplicity:
         description: "Data multiplicity (redundancy)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.pdbx_redundancy
       cc_half:
         description: "Half-set correlation coefficient CC(1/2)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.pdbx_CC_half
       r_merge:
         description: "Rmerge - merge R-factor"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.pdbx_Rmerge_I_obs
       r_pim:
         description: "Rpim - precision-indicating merging R-factor"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.pdbx_Rpim_I_all
       wilson_b_factor_a2:
         description: "Wilson B-factor in Angstroms squared"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.B_iso_Wilson_estimate
       anomalous_used:
         description: "Whether anomalous signal was used"
         range: boolean
@@ -2303,6 +2419,8 @@ classes:
         description: "Anomalous correlation"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_reflns.pdbx_CC_half_anomalous
       anom_sig_ano:
         description: "Anomalous signal strength"
         range: QuantityValue
@@ -2312,22 +2430,32 @@ classes:
         description: "Refinement R-factor (working set)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_refine.ls_R_factor_R_work
       r_free:
         description: "R-free (test set)"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_refine.ls_R_factor_R_free
       ramachandran_favored_percent:
         description: "Percentage of residues in favored Ramachandran regions"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_pdbx_struct_quality.ramachandran_favored
       ramachandran_outliers_percent:
         description: "Percentage of Ramachandran outliers"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_pdbx_struct_quality.ramachandran_outliers
       clashscore:
         description: "MolProbity clashscore"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_pdbx_struct_quality.clashscore
       molprobity_score:
         description: "Overall MolProbity score"
         range: QuantityValue
@@ -2336,6 +2464,8 @@ classes:
         description: "Average B-factor in Angstroms squared"
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_refine.B_iso_mean
       # SAXS metrics
       i_zero:
         description: "Forward scattering intensity I(0)"
@@ -2477,6 +2607,8 @@ classes:
       symmetry:
         description: "Symmetry applied (C1, Cn, Dn, T, O, I)"
         range: SymmetryEnum
+        exact_mappings:
+          - mmCIF:_em_3d_reconstruction.symmetry_type
       pixel_size:
         description: "Pixel size, typically specified in Angstroms per pixel. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
@@ -2495,6 +2627,8 @@ classes:
         description: "Resolution at FSC=0.143, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        exact_mappings:
+          - mmCIF:_em_3d_reconstruction.resolution
       resolution_0_5:
         description: "Resolution at FSC=0.5, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue


### PR DESCRIPTION
## Summary
- Add `gen-sssom` Makefile target to generate SSSOM TSV from schema `exact_mappings`
- Convert 21 `slot_uri` annotations (nsls2, mmCIF) to `exact_mappings` — `slot_uri` is for RDF serialization identity, not semantic mappings, and `gen-sssom` only captures `*_mappings`
- Add ~75 new mmCIF `exact_mappings` across: CryoEMInstrument, CryoEMPreparation, QualityMetrics, DataCollectionStrategy, ExperimentRun, XRayInstrument, XRayPreparation, CrystallizationConditions, RefinementParameters, WorkflowRun, Sample
- Fix 4 incorrect mmCIF mappings on WorkflowRun (`rmsd_bonds`→was `_refine.ls_d_res_high`, `rmsd_angles`→was `_refine.ls_d_res_low`, `ramachandran_favored`→was `_refine.pdbx_overall_ESU_R`, `ramachandran_outliers`→was `_refine.pdbx_overall_ESU_R_Free`)
- Generated SSSOM: **234 mapping rows, 98 mmCIF/PDB entries** (up from ~20)

## Test plan
- [ ] `make gen-sssom` produces `assets/sssom/lambda_ber_schema.sssom.tsv`
- [ ] `linkml-lint` shows no new warnings (82 pre-existing)
- [ ] `make test` passes
- [ ] Spot-check mmCIF mappings against [PDBx/mmCIF dictionary](http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)