### PR TITLE
emsl science central 

### DIFF
--- a/emsl-dev/README.md
+++ b/emsl-dev/README.md
@@ -1,0 +1,163 @@
+# emsl-dev/
+
+Development artifacts for the EMSL Science Central ETL integration.
+
+---
+
+## Files
+
+### `swagger.json`
+
+The OpenAPI 2.0 (Swagger) specification for the EMSL Science Central public API, retrieved from `https://api.emsl.pnnl.gov/external/swagger.json`.
+
+Key endpoints documented:
+
+| Endpoint | Auth | Used by loader |
+|---|---|---|
+| `POST /datasets/by_sample_name` | None | Yes — sample search |
+| `GET /projects/{id}` | None | Yes — project/study metadata |
+| `GET /resources/{id}` | None | Yes — instrument metadata |
+| `GET /datasets/transaction_info/{tx_id}` | None | Yes — file listing |
+| `GET /datasets/request/{tx_id}` | JWT | Yes — create download cart |
+| `GET /datasets/download/{uuid}` | JWT | Yes — poll cart status |
+| `DELETE /datasets/download/{uuid}` | JWT | No — cleanup only |
+| `GET /datasets/info/{uuid}` | JWT | No — richer cart status |
+| `GET /resources/all` | None | No — full instrument list |
+| `GET /resources/grouping` | None | No — instrument classification |
+| `GET /projects/data/{id}` | None | No — per-dataset release status |
+
+> **Note:** The swagger schema defines `status` as an untyped string with no enum. Observed real values: `"waiting"` (not ready), `"staging"` (tape recall in progress), `"transfer"` (ready). The swagger's implied values (`"ready"`, `"complete"`) have never been observed in production.
+
+---
+
+### `api-field-inventory.yaml`
+
+A field-by-field inventory of every response value available from the four active endpoints, annotated with:
+
+- `loader_status`: `captured` / `ignored` / `not_used`
+- `schema_target`: which schema class and field the value maps to
+- `notes`: naming conventions, caveats, and observed examples
+
+Covers:
+- `POST /datasets/by_sample_name` — wrapper fields + `SampleTransaction` fields
+- `GET /projects/{id}` — project/PI/member fields
+- `GET /resources/{id}` — instrument fields
+- `GET /datasets/transaction_info/{tx_id}` — file listing fields
+
+Also includes the three unused endpoints (`/resources/all`, `/resources/grouping`, `/projects/data/{id}`) with their available fields and relevance notes.
+
+---
+
+### `api-to-schema-mapping.yaml`
+
+Cross-reference between every API field and the `lambda-ber-schema` schema. Organized into four sections:
+
+| Section | Meaning |
+|---|---|
+| **A. `captured`** | API field → schema field exists and loader maps it |
+| **B. `loader_gaps`** | Schema field exists but loader does not populate it |
+| **C. `schema_gaps`** | API field has no matching schema field (schema change needed) |
+| **D. `schema_fields_without_api_source`** | Schema field exists but API doesn't expose it |
+
+**Key findings:**
+
+- **Loader currently creates base `Instrument`**, not `CryoEMInstrument` — all 8+ instrument spec fields (`accelerating_voltage`, `detector_model`, `cs`, etc.) are permanently unreachable until this is fixed (Phase 1 work).
+- **`resource.active` is always `false`** for observed live instruments — known API bug; reference data should override.
+- **`project_members[]`** contains ORCID, name, role, and institution — none is captured; no matching schema field exists at all (`Study.contributors` not yet in schema).
+- **`is_released`** (from `/projects/data/{id}`) has no schema equivalent — `Dataset` has no embargo/release-status field.
+
+**Highest-priority schema additions:**
+
+1. `Study.contributors` — list with orcid, name, role, institution
+2. `Study.award_doi` — currently stored only on `LoaderResult`, lost after serialization
+3. `Dataset.is_released` — boolean or enum (embargoed/public/restricted)
+4. `Instrument.website` — promote from `BeamlineInstrument` to base `Instrument`
+
+---
+
+### `metadata-sources.yaml`
+
+Catalogue of metadata sources for the three categories of acquisition/instrument/sample data that the public Science Central API does **not** expose. Each source entry includes: location in the data pipeline, format, access method, available fields, feasibility rating, and implementation notes.
+
+**Acquisition metadata** (magnification, pixel size, dose, defocus, etc.):
+
+| Source | Feasibility | Status |
+|---|---|---|
+| EPU Session XML (inside `.tar` archives) | High | Implemented (Phase 2) — blocked on tape staging |
+| EPU Session Summary YAML | Medium | Unverified — needs confirmation with PNNL |
+| SerialEM `.mdoc` files (tomography) | High | Not implemented |
+| EMSL AURORA / KriosGPU | Low | Internal systems, not publicly accessible |
+
+**Instrument metadata** (accelerating voltage, detector model, Cs, etc.):
+
+| Source | Feasibility | Status |
+|---|---|---|
+| `reference-data/facilities/emsl.yaml` (in-repo) | High | Exists but **currently ignored by loader** — Phase 1 work |
+| `/resources/grouping` API call | High | Not called — would replace name-regex heuristics |
+| BER Structural Biology Portal (manual curation) | High | Ground-truth for static specs |
+
+**Sample/biological metadata** (organism, buffer, grid prep, etc.):
+
+| Source | Feasibility | Status |
+|---|---|---|
+| EMSL User Proposal system | Low | Not in public API |
+| `project.title` / `project.abstract` (NLP) | Medium | Not implemented |
+| EMPIAR / EMDB (deposited datasets only) | Medium | Retroactive enrichment only |
+
+---
+
+### `jwt-auth.yaml`
+
+JWT authentication notes for the download-cart endpoints.
+
+**Auth surface:** Only the download cart and file download endpoints require a token. The four primary metadata endpoints are public (no auth).
+
+**Flow:** OIDC `client_credentials` grant → bearer token → `EMSL_JWT` env var → `--token` CLI flag.
+
+**Observed cart status lifecycle:**
+
+```
+waiting / "In Preparation"  →  staging / "File Retrieval"  →  transfer / "File Retrieval"
+   (cart created)                (tape recall in progress)        (file ready to download)
+```
+
+> **Important API discrepancy:** `/datasets/download/{uuid}` and `/datasets/info/{uuid}` return different data for the same cart. During staging, `/download` shows `success: false, retrieval_url: null`; `/info` shows `success: true, retrieval_url: <path>`. Use `status == "transfer"` (not `success: true`) as the real readiness signal. The retrieval URL base is `/download_tracking/cart/{uuid}`, not `/external/`.
+
+**Tape staging times:** Observed staging duration for a 366 MB single-file transaction is >90 minutes. EMSL uses Spectra Logic tape (HSM). Staging time depends on tape mount queue and whether the file has been recently accessed. The default `--epu-timeout` in the CLI is 30 minutes (1800 s); for cold-storage files increase to 2+ hours.
+
+**Cart lifecycle:** Carts do not auto-cancel. Stale carts in `staging` state are harmless. Once a tape recall completes, the cart transitions to `transfer` and the download URL becomes active. Subsequent carts for the same transaction stage quickly (disk cache hit).
+
+---
+
+## Related Code
+
+| File | Purpose |
+|---|---|
+| `src/lambda_ber_schema/loaders/emsl.py` | EMSL ETL loader — all API calls, EPU extraction, cart handling |
+| `src/lambda_ber_schema/cli.py` | CLI entry point — `etl emsl` command with `--extract-epu`, `--token`, `--epu-timeout` |
+| `reference-data/facilities/emsl.yaml` | Static instrument specs for Krios G3i and Aquilos 2 (currently ignored by loader) |
+| `examples/Dataset-emsl-tx-*.yaml` | Example outputs from the loader for three PNCC transactions |
+
+## Implementation Roadmap
+
+**Phase 1 (no JWT required):**
+- Upgrade loader to create `CryoEMInstrument` instead of base `Instrument`
+- Merge `reference-data/facilities/emsl.yaml` at loader init to populate instrument spec fields
+- Fix `current_status: offline` bug (override API's `active=false` using reference data)
+- Call `/resources/grouping` to replace fragile name-regex instrument classification
+
+**Phase 2 (JWT required — implemented, tape staging blocking demo):**
+- EPU session XML extraction from `.tar` archives via download cart
+- CLI flags: `--extract-epu`, `--token`, `--epu-timeout`
+- Populates 13 `ExperimentRun` acquisition fields (magnification, dose, pixel size, etc.)
+
+**Phase 3 (schema additions):**
+- Add `Study.contributors` (orcid, name, role, institution)
+- Add `Study.award_doi`
+- Add `Dataset.is_released`
+- Promote `Instrument.website` from `BeamlineInstrument` to base `Instrument`
+
+**Phase 4 (future):**
+- SerialEM `.mdoc` parser for tomography transactions
+- NLP extraction of biological context from `project.abstract`
+- EMPIAR cross-link for deposited datasets

--- a/emsl-dev/api-field-inventory.yaml
+++ b/emsl-dev/api-field-inventory.yaml
@@ -1,0 +1,621 @@
+# EMSL Science Central Public API — CryoEM Metadata Field Inventory
+#
+# Base URL: https://api.emsl.pnnl.gov/external
+# Swagger:  https://api.emsl.pnnl.gov/external/swagger.json
+# Scope:    CryoEM transactions at PNCC (Pacific Northwest Cryo-EM Center)
+# Prepared: 2026-04-03
+#
+# Status values for loader_status:
+#   captured   – field is fetched and mapped to the lambda-ber schema
+#   ignored    – field is fetched but deliberately not mapped
+#   not_used   – field exists in API but no fetch/call is made
+#
+# Schema target uses dotted class.field notation.
+
+endpoints:
+
+  # ─────────────────────────────────────────────────────────────────
+  # 1. POST /datasets/by_sample_name
+  #    Search transactions by sample name.
+  #    Returns wrapper + list of Sample Transaction objects.
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: POST /datasets/by_sample_name
+    description: >
+      Primary search entry point. Given a sample name string, returns a list
+      of matching Pacifica transaction records. Each transaction represents a
+      single data-collection session on one instrument under one project.
+    cryo_em_relevance: primary
+    currently_called: true
+
+    request_fields:
+      - name: sample_name
+        type: string
+        required: true
+        example: "apo"
+        notes: "SQL LIKE wildcard (%) supported in 'like' mode; regex in 'regex' mode"
+      - name: search_mode
+        type: string
+        enum: [like, regex, fuzzy]
+        default: like
+        notes: "fuzzy returns similarity_score; like ~2-3s, regex ~3-5s, fuzzy ~2-4s"
+      - name: key_filter
+        type: string
+        example: "pncc"
+        notes: >
+          Filters which metadata key is searched. 'pncc' targets cryo-EM keys
+          (e.g., pncc.short_sample_name, pncc.session_id). Omit to search all
+          keys containing 'sample'. Default in loader: 'pncc'.
+      - name: exact_match
+        type: boolean
+        default: false
+      - name: case_sensitive
+        type: boolean
+        default: false
+      - name: similarity_threshold
+        type: number
+        default: 0.6
+        notes: "Only applies to fuzzy mode. Range 0.0–1.0."
+      - name: limit
+        type: integer
+        default: 20
+        max: 100
+      - name: offset
+        type: integer
+        default: 0
+        notes: "Pagination offset"
+
+    response_wrapper_fields:
+      - name: total_count
+        type: integer
+        example: 571
+        loader_status: ignored
+        notes: "Total matching transactions across all pages; not captured in schema"
+      - name: search_mode
+        type: string
+        example: like
+        loader_status: ignored
+      - name: limit
+        type: integer
+        loader_status: ignored
+      - name: offset
+        type: integer
+        loader_status: ignored
+
+    response_transaction_fields:
+      - name: transaction_id
+        type: integer
+        example: 3736677
+        loader_status: captured
+        schema_target: ExperimentRun.id  # minted as emsl:transaction_{tx_id}
+        notes: "Primary identifier; also used as Dataset.id and Experiment.id"
+
+      - name: sample_key
+        type: string
+        example: "pncc.short_sample_name"
+        loader_status: captured
+        schema_target: Sample.description
+        notes: >
+          Metadata key from the Pacifica instrument metadata store. Known CryoEM keys:
+            pncc.short_sample_name – primary sample label set by user at data collection
+            pncc.session_id        – EPU session identifier (may duplicate sample name)
+          Stored in Sample.description as "Source key: {sample_key}". Not mapped to
+          a dedicated schema field.
+
+      - name: sample_value
+        type: string
+        example: "T-A-apo_5_021226_data"
+        loader_status: captured
+        schema_target: Sample.sample_code, Sample.title
+        notes: >
+          The actual sample name string. Naming conventions observed at PNCC:
+            {protein}_{date}_data   – raw data collection session
+            {protein}_{date}_atlas  – atlas/grid-map session
+            {protein}_{date}        – generic session
+
+      - name: submitter_id
+        type: integer
+        example: 48279
+        loader_status: captured
+        schema_target: ExperimentRun.operator_id
+        notes: >
+          EMSL internal user ID of the person who submitted the upload. Not a public
+          ORCID; no lookup endpoint is available in the public API.
+
+      - name: instrument_id
+        type: integer
+        example: 34290
+        loader_status: captured
+        schema_target: Instrument.id  # via _fetch_resource(); minted as emsl:resource_{id}
+        notes: >
+          Triggers a GET /resources/{id} call to enrich instrument metadata.
+          Missing when loading via load_transaction() pathway.
+
+      - name: project_id
+        type: string
+        example: "160724"
+        loader_status: captured
+        schema_target: Study.id  # minted as emsl:project_{project_id}
+        notes: "Triggers a GET /projects/{id} call to enrich study metadata."
+
+      - name: created
+        type: string
+        format: ISO 8601 datetime (naive, no timezone)
+        example: "2026-02-15T15:46:44"
+        loader_status: captured
+        schema_target: ExperimentRun.experiment_date, DataFile.creation_date
+        notes: >
+          Time the transaction was created in Science Central (i.e., upload
+          timestamp, not necessarily the microscope collection start time).
+          Treated as UTC by the loader.
+
+      - name: similarity_score
+        type: number
+        example: null
+        loader_status: ignored
+        notes: "Only populated in fuzzy search mode. Not mapped to schema."
+
+  # ─────────────────────────────────────────────────────────────────
+  # 2. GET /projects/{project_identifier}
+  #    Full project record including PI roster.
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: GET /projects/{project_identifier}
+    description: >
+      Full details for a single EMSL project (allocation). Project ID is a
+      short integer string (e.g., "160724"). Also accessible by UUID.
+    cryo_em_relevance: primary
+    currently_called: true
+
+    response_fields:
+      - name: id
+        type: string
+        example: "160724"
+        loader_status: ignored
+        notes: "Short project identifier; already known from transaction"
+
+      - name: uuid
+        type: string
+        example: "43fd68fd-2f06-5288-96f0-613ec567c29d"
+        loader_status: ignored
+        notes: "Long-form UUID; could be used as more stable identifier"
+
+      - name: uri
+        type: string
+        example: "/external/projects/160724"
+        loader_status: ignored
+        notes: "Relative URI within the API"
+
+      - name: title
+        type: string
+        example: "Single particle cryo-EM analysis of human PARP enzymes: mechanisms of regulation and inhibition"
+        loader_status: captured
+        schema_target: Study.title
+
+      - name: abstract
+        type: string
+        example: "Human PARP enzymes are a diverse class of medically relevant proteins..."
+        loader_status: captured
+        schema_target: Study.description
+
+      - name: project_type
+        type: string
+        example: "General Access"
+        loader_status: captured
+        schema_target: Study.keywords[]
+        notes: "Added to keywords list alongside 'EMSL'"
+
+      - name: active
+        type: boolean
+        example: true
+        loader_status: ignored
+        notes: "Project active status; not mapped to schema"
+
+      - name: accepted
+        type: boolean
+        example: true
+        loader_status: ignored
+        notes: "Whether allocation was accepted; not mapped to schema"
+
+      - name: award_doi
+        type: string
+        example: null
+        loader_status: captured
+        schema_target: LoaderResult.doi
+        notes: "Normalized to https://doi.org/{doi} if not already a URL"
+
+      - name: started_date
+        type: string
+        format: date (YYYY-MM-DD)
+        example: "2025-08-29"
+        loader_status: not_captured
+        schema_target: Study.start_date  # field exists in schema as string
+        notes: "Available in response but NOT currently mapped. Should populate Study.start_date."
+
+      - name: closed_date
+        type: string
+        format: date (YYYY-MM-DD)
+        example: null
+        loader_status: not_captured
+        schema_target: Study.end_date
+        notes: "Available in response but NOT currently mapped."
+
+      - name: current_status
+        type: string
+        example: "started"
+        loader_status: not_captured
+        notes: "Project allocation status (started/closed/etc). Not currently mapped."
+
+      - name: "project_members[].project_role"
+        type: string
+        example: "principal_investigator"
+        loader_status: not_captured
+        notes: >
+          Known values: principal_investigator, active_member, collaborator.
+          Not mapped; could populate Study.principal_investigator or contributors.
+
+      - name: "project_members[].orcid"
+        type: string
+        example: "0000-0002-2714-4317"
+        loader_status: not_captured
+        schema_target: Study.principal_investigator  # or a contributor list
+        notes: "ORCID identifier for the PI / member. Available but not captured."
+
+      - name: "project_members[].institution"
+        type: string
+        example: "Université de Montreal"
+        loader_status: not_captured
+        notes: "PI/member institution. Available but not captured."
+
+      - name: "project_members[].first_name"
+        type: string
+        example: "John"
+        loader_status: not_captured
+
+      - name: "project_members[].last_name"
+        type: string
+        example: "Pascal"
+        loader_status: not_captured
+
+  # ─────────────────────────────────────────────────────────────────
+  # 3. GET /resources/{resource_id}
+  #    Instrument/resource details.
+  #    Returns a list with one item (unusual but observed).
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: GET /resources/{resource_id}
+    description: >
+      Returns metadata for a specific EMSL instrument/resource. The response is
+      a JSON array containing a single object (not a bare object).
+    cryo_em_relevance: primary
+    currently_called: true
+
+    response_fields:
+      - name: id
+        type: integer
+        example: 34290
+        loader_status: captured
+        schema_target: Instrument.id  # minted as emsl:resource_{id}
+
+      - name: name
+        type: string
+        example: "PNCC Krios 1"
+        loader_status: captured
+        schema_target: Instrument.model
+        notes: "Short instrument name. Used for technique and category inference."
+
+      - name: display_name
+        type: string
+        example: "PNCC Krios 1 (34290)"
+        loader_status: captured
+        schema_target: Instrument.title
+
+      - name: active
+        type: boolean
+        example: false
+        loader_status: captured
+        schema_target: Instrument.current_status
+        notes: >
+          Maps true → operational, false → offline. KNOWN ISSUE: the API returns
+          active=false for all observed resources even when instruments are in use.
+          This is likely a Science Central data quality issue, not a decommission.
+
+      - name: location
+        type: string
+        example: "EMSL/1095"
+        loader_status: captured
+        schema_target: Instrument.description  # concatenated with available_hours
+        notes: "Building/room location within EMSL campus"
+
+      - name: available_hours
+        type: string
+        example: "24/7"
+        loader_status: captured
+        schema_target: Instrument.description  # concatenated with location
+
+      - name: url
+        type: string
+        example: "/resources/34290"
+        loader_status: not_captured
+        notes: >
+          Relative URL path for this resource in the API. Not currently
+          mapped to Instrument. Could be used to build a full resource URL.
+
+    observed_cryo_em_resources:
+      - resource_id: 34290
+        name: "PNCC Krios 1"
+        notes: "Titan Krios at PNCC; EPU acquisition"
+      - resource_id: 34251
+        name: "PNCC Arctica"
+        notes: "Talos Arctica at PNCC"
+      - resource_id: 34252
+        name: "PNCC Krios 2 (inferred)"
+        notes: "Observed in sample search; not confirmed"
+      - resource_id: 34292
+        name: "PNCC Krios 3 or Arctica 2 (inferred)"
+        notes: "Observed in sample search; not confirmed"
+      - resource_id: 135003
+        name: "Unknown (inferred)"
+        notes: "Observed in sample search; instrument type unknown"
+
+  # ─────────────────────────────────────────────────────────────────
+  # 4. GET /datasets/transaction_info/{transaction_id}
+  #    File listing for a transaction.
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: GET /datasets/transaction_info/{transaction_id}
+    description: >
+      Returns the list of files uploaded in a transaction. Response is keyed by
+      transaction_id: { "{tx_id}": [{file}, ...] }. Files are typically large
+      multi-part .tar archives of raw cryo-EM frames.
+    cryo_em_relevance: primary
+    currently_called: true
+
+    response_fields:
+      - name: file_id
+        type: integer
+        example: 64895567
+        loader_status: captured
+        schema_target: DataFile.id  # minted as emsl:file_{file_id}
+
+      - name: name
+        type: string
+        example: "87ffc243efcf23cc97850c900d93d62a25087827.data.1.tar"
+        loader_status: captured
+        schema_target: DataFile.file_name
+        notes: >
+          File naming pattern for cryo-EM data:
+            {sha1_hash}.data.{n}.tar      – split tar archive of raw movie frames
+            *atlas*                        – FluiDic/EPU atlas session files
+            *.xml, *.mrc, *.tiff          – EPU session metadata / micrographs
+          Hash prefix is the SHA1 of the original EPU session folder.
+
+      - name: path
+        type: string
+        example: "160724/T-A-apo_5_021226_data/epu_session"
+        loader_status: captured
+        schema_target: DataFile.file_path, ExperimentRun.raw_data_location
+        notes: >
+          Three-part relative path: {project_id}/{sample_name}/{subdir}
+          Known subdirectory names and their meaning:
+            epu_session   → EPU software; raw frame collection
+            serialem      → SerialEM software
+            leginon       → Leginon software
+            atlas         → Grid atlas / montage session
+            processed     → downstream processing outputs
+          Used by loader to infer acquisition_software.
+
+      - name: size
+        type: integer
+        example: 146741698560
+        loader_status: captured
+        schema_target: DataFile.file_size_bytes  # as QuantityValue(numeric_value, unit="bytes")
+        notes: "Size in bytes. Typical PNCC tar part: 130–160 GB per file."
+
+      - name: transaction_id
+        type: integer
+        example: 3736677
+        loader_status: ignored
+        notes: "Redundant with the key used to look up the transaction"
+
+  # ─────────────────────────────────────────────────────────────────
+  # 5. GET /projects/data/{project_identifier}   [NOT CURRENTLY USED]
+  #    All transactions for a project with release status.
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: GET /projects/data/{project_identifier}
+    description: >
+      Returns a project record plus all of its datasets (transactions) with
+      file count/size summaries and a public-release flag. Supports pagination.
+      NOT currently called by the loader.
+    cryo_em_relevance: high
+    currently_called: false
+
+    response_fields:
+      - name: project
+        type: object
+        notes: "Same structure as /projects/{id} but abbreviated (no members)"
+
+      - name: "datasets[].upload_identifier"
+        type: integer
+        example: 3736677
+        loader_status: not_used
+        notes: "Same as transaction_id. Could enumerate all transactions in a project."
+
+      - name: "datasets[].resource"
+        type: object
+        loader_status: not_used
+        notes: "Inline resource object (same as /resources/{id} response)"
+
+      - name: "datasets[].date_created"
+        type: string
+        format: date (YYYY-MM-DD)
+        loader_status: not_used
+        notes: "Date part of the transaction creation timestamp"
+
+      - name: "datasets[].is_released"
+        type: boolean
+        loader_status: not_used
+        notes: >
+          Whether this transaction's data is publicly released. Important for
+          dataset visibility/embargo tracking. NOT currently captured in schema.
+
+      - name: "datasets[].total_file_count"
+        type: integer
+        loader_status: not_used
+        notes: "File count without calling transaction_info. Useful for quick summaries."
+
+      - name: "datasets[].total_file_size"
+        type: integer
+        loader_status: not_used
+        notes: "Total bytes across all files in the transaction."
+
+      - name: "datasets[].friendly_file_size"
+        type: object
+        loader_status: not_used
+        notes: "Human-readable size object (e.g., {value: 136.8, unit: 'GB'})"
+
+  # ─────────────────────────────────────────────────────────────────
+  # 6. GET /resources/grouping   [NOT CURRENTLY USED]
+  #    Maps resource IDs to named instrument groups.
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: GET /resources/grouping
+    description: >
+      Returns a list mapping each resource to a named group. Useful for
+      classifying instruments (e.g., all PNCC Krios instruments in one group).
+      NOT currently called.
+    cryo_em_relevance: medium
+    currently_called: false
+
+    response_fields:
+      - name: resource_uuid
+        type: string
+        loader_status: not_used
+      - name: resource_id
+        type: string
+        loader_status: not_used
+      - name: resource_name
+        type: string
+        loader_status: not_used
+        notes: "Human-readable name; could replace regex-based technique inference"
+      - name: group
+        type: string
+        loader_status: not_used
+        notes: "Named group (e.g., 'PNCC', 'EMSL Cryo-ET'). Could improve instrument_category inference."
+
+  # ─────────────────────────────────────────────────────────────────
+  # 7. GET /datasets/request/{transaction_id}   [NOT CURRENTLY USED]
+  #    Create a download cart for a transaction.
+  # ─────────────────────────────────────────────────────────────────
+  - endpoint: GET /datasets/request/{transaction_id}
+    description: >
+      Creates a download cart for a transaction and returns a retrieval URL.
+      This is the actual data download mechanism. NOT currently implemented.
+    cryo_em_relevance: high (for data access)
+    currently_called: false
+
+    response_fields:
+      - name: download_uuid
+        type: string
+        loader_status: not_used
+        notes: "UUID to poll /datasets/download/{uuid} for status"
+      - name: status
+        type: string
+        loader_status: not_used
+      - name: success
+        type: boolean
+        loader_status: not_used
+      - name: message
+        type: string
+        loader_status: not_used
+      - name: display_status
+        type: string
+        loader_status: not_used
+      - name: retrieval_url
+        type: string
+        loader_status: not_used
+        notes: "Globus or direct download URL for the data"
+      - name: status_url
+        type: string
+        loader_status: not_used
+        notes: "URL to poll for async cart-preparation progress"
+
+# ─────────────────────────────────────────────────────────────────
+# SUMMARY: Fields Available but NOT Captured
+# ─────────────────────────────────────────────────────────────────
+gaps:
+  high_priority:
+    - field: "project.started_date / closed_date"
+      endpoint: GET /projects/{id}
+      notes: "Project allocation dates. Map to Study.start_date / Study.end_date."
+
+    - field: "project_members[].orcid + .project_role + .institution"
+      endpoint: GET /projects/{id}
+      notes: >
+        PI and team ORCID IDs, roles, and institutions. PI could populate
+        Study.principal_investigator. Requires schema field addition or use of
+        Study.keywords / description as fallback.
+
+    - field: "datasets[].is_released"
+      endpoint: GET /projects/data/{project_id}
+      notes: >
+        Public-release flag per transaction. No corresponding schema field exists.
+        Important for open-data tracking.
+
+  medium_priority:
+    - field: "resource.url"
+      endpoint: GET /resources/{id}
+      notes: "Instrument URL (e.g., /resources/34290). Map to Instrument.website."
+
+    - field: "resource.active (data quality fix)"
+      endpoint: GET /resources/{id}
+      notes: >
+        Currently maps active=false → InstrumentStatusEnum.offline for all
+        observed resources. Should cross-reference with reference-data/facilities/emsl.yaml
+        rather than trusting the API active flag.
+
+    - field: "datasets[].total_file_count / total_file_size"
+      endpoint: GET /projects/data/{project_id}
+      notes: "Could populate Dataset summary fields without listing all files."
+
+    - field: "resource grouping"
+      endpoint: GET /resources/grouping
+      notes: "Could replace regex-based instrument category inference."
+
+  out_of_scope_for_cryo_em:
+    - endpoint: /monet/*
+      notes: "MONet environmental/soil sample data portal. Not relevant for cryo-EM."
+    - field: "similarity_score"
+      endpoint: POST /datasets/by_sample_name
+      notes: "Only meaningful for fuzzy search UX; no schema representation needed."
+    - field: transaction.submitter_id
+      notes: "Internal EMSL user ID; no public lookup available."
+
+# ─────────────────────────────────────────────────────────────────
+# OBSERVED SAMPLE KEY PATTERNS (cryo-EM)
+# ─────────────────────────────────────────────────────────────────
+observed_sample_keys:
+  - key: pncc.short_sample_name
+    example: "T-A-apo_5_021226_data"
+    notes: "Primary cryo-EM sample label; set by user in EPU/Science Central at session start"
+  - key: pncc.session_id
+    example: "T-A-apo_5"
+    notes: "EPU session ID; may be a substring of short_sample_name; can duplicate across transactions"
+
+# ─────────────────────────────────────────────────────────────────
+# OBSERVED FILE PATH PATTERNS (cryo-EM)
+# ─────────────────────────────────────────────────────────────────
+observed_file_patterns:
+  path_structure: "{project_id}/{sample_name}/{subdir}/{filename}"
+  subdirectory_meanings:
+    epu_session:   "Raw EPU data collection (multi-part .tar archives of movie frames)"
+    serialem:      "SerialEM acquisition session"
+    leginon:       "Leginon acquisition session"
+    atlas:         "Grid atlas / montage collection (smaller files, .mrc montages)"
+    processed:     "Downstream processing output (not raw data)"
+  filename_patterns:
+    - pattern: "{sha1}.data.{n}.tar"
+      notes: "Multi-part split tar of EPU raw movie frames; each part ~130-160 GB"
+    - pattern: "*.mrc"
+      notes: "MRC-format micrographs or montages"
+    - pattern: "*.tiff / *.tif"
+      notes: "TIFF movie frames"
+    - pattern: "*.xml"
+      notes: "EPU session metadata / acquisition parameter XML files"
+    - pattern: "notes.txt"
+      notes: "Session notes; typically small"

--- a/emsl-dev/api-to-schema-mapping.yaml
+++ b/emsl-dev/api-to-schema-mapping.yaml
@@ -1,0 +1,563 @@
+# EMSL Science Central API → lambda-ber-schema Field Mapping
+#
+# Cross-reference between every API field available from the public Science Central
+# API and every field in the lambda-ber schema, for cryo-EM datasets.
+#
+# Three categories:
+#   A.  API field → schema field EXISTS and loader captures it
+#   B.  API field → schema field EXISTS but loader does NOT capture it (gap in loader)
+#   C.  API field → NO matching schema field (gap in schema)
+#   D.  Schema field EXISTS → no API source (field can't be populated from API alone)
+#
+# Prepared: 2026-04-03
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A. API → SCHEMA: Captured (loader maps these correctly)
+# ─────────────────────────────────────────────────────────────────────────────
+captured:
+
+  # --- Study (from GET /projects/{id}) ---
+  - api_source: "project.title"
+    schema_class: Study
+    schema_field: title
+    notes: "Mapped directly"
+
+  - api_source: "project.abstract"
+    schema_class: Study
+    schema_field: description
+    notes: "Mapped directly"
+
+  - api_source: "project.project_type"
+    schema_class: Study
+    schema_field: "keywords[]"
+    notes: "Appended to keyword list alongside 'EMSL'"
+
+  - api_source: "project.award_doi"
+    schema_class: LoaderResult
+    schema_field: doi
+    notes: "Normalized to https://doi.org/{doi}. NOT stored on Study itself."
+
+  # --- Sample (from transaction search result) ---
+  - api_source: "transaction.sample_value"
+    schema_class: Sample
+    schema_field: sample_code
+    notes: "The user-assigned sample label (e.g., 'T-A-apo_5_021226_data')"
+
+  - api_source: "transaction.sample_value"
+    schema_class: Sample
+    schema_field: title
+    notes: "Same value used as title"
+
+  - api_source: "transaction.sample_key"
+    schema_class: Sample
+    schema_field: description
+    notes: "Stored as 'Source key: {sample_key}'. Metadata key only, not a rich description."
+
+  - api_source: "transaction.sample_value (inferred)"
+    schema_class: Sample
+    schema_field: sample_type
+    notes: "Inferred by regex over sample text; not read from API directly"
+
+  # --- ExperimentRun (from transaction) ---
+  - api_source: "transaction.transaction_id"
+    schema_class: ExperimentRun
+    schema_field: experiment_code
+    notes: "Formatted as 'EMSL-TX-{tx_id}'"
+
+  - api_source: "transaction.created"
+    schema_class: ExperimentRun
+    schema_field: experiment_date
+    notes: "ISO timestamp from Science Central upload time (not microscope start time)"
+
+  - api_source: "transaction.submitter_id"
+    schema_class: ExperimentRun
+    schema_field: operator_id
+    notes: "Stored as string of EMSL internal user ID; no name/ORCID available"
+
+  - api_source: "transaction (inferred from sample_key + resource)"
+    schema_class: ExperimentRun
+    schema_field: technique
+    notes: "Inferred by regex; defaults to cryo_em for PNCC transactions"
+
+  - api_source: "files[0].path"
+    schema_class: ExperimentRun
+    schema_field: raw_data_location
+    notes: "Path of first file used as raw data location"
+
+  - api_source: "files[].path (subdir inference)"
+    schema_class: ExperimentRun
+    schema_field: acquisition_software
+    notes: "epu_session→EPU, serialem→SerialEM, leginon→Leginon"
+
+  # --- Instrument (from GET /resources/{id}) ---
+  - api_source: "resource.id"
+    schema_class: Instrument
+    schema_field: id
+    notes: "Minted as emsl:resource_{id}"
+
+  - api_source: "resource.display_name"
+    schema_class: Instrument
+    schema_field: title
+    notes: "e.g., 'PNCC Krios 1 (34290)'"
+
+  - api_source: "resource.name"
+    schema_class: Instrument
+    schema_field: model
+    notes: "Short name e.g., 'PNCC Krios 1'; also used for category/technique inference"
+
+  - api_source: "resource.active"
+    schema_class: Instrument
+    schema_field: current_status
+    notes: >
+      true → operational, false → offline. KNOWN BUG: all observed live resources
+      return active=false despite being operational.
+
+  - api_source: "resource.location + resource.available_hours"
+    schema_class: Instrument
+    schema_field: description
+    notes: "Concatenated as 'EMSL/1095 | 24/7'"
+
+  # --- DataFile (from GET /datasets/transaction_info/{tx_id}) ---
+  - api_source: "file.file_id"
+    schema_class: DataFile
+    schema_field: id
+    notes: "Minted as emsl:file_{file_id}"
+
+  - api_source: "file.name"
+    schema_class: DataFile
+    schema_field: file_name
+
+  - api_source: "file.path + file.name"
+    schema_class: DataFile
+    schema_field: file_path
+
+  - api_source: "file.size"
+    schema_class: DataFile
+    schema_field: file_size_bytes
+    notes: "Stored as QuantityValue(numeric_value=float(size), unit='bytes')"
+
+  - api_source: "file.name (extension inference)"
+    schema_class: DataFile
+    schema_field: file_format
+    notes: ".tar→tar, .mrc→mrc, .tiff→tiff, etc."
+
+  - api_source: "transaction.created"
+    schema_class: DataFile
+    schema_field: creation_date
+    notes: "Transaction upload time applied to all files; individual file timestamps not in API"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B. API → SCHEMA: Field Exists in Schema, NOT Captured by Loader
+#    (Loader gaps — code changes needed, no schema changes)
+# ─────────────────────────────────────────────────────────────────────────────
+loader_gaps:
+
+  - api_source: "project.started_date"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+    notes: >
+      Study has no start_date field. The NamedThing base has only id/title/description.
+      See schema_gaps below — this needs a schema addition too.
+
+  - api_source: "project.closed_date"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+    notes: "Same as above — no end_date on Study"
+
+  - api_source: "project.current_status"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+    notes: "No project_status or is_active field on Study"
+
+  - api_source: "project.award_doi"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+    notes: >
+      DOI is currently stored on LoaderResult.doi, not on Study. There is no
+      Study.award_doi or Study.doi field. A Study-level DOI field would be useful
+      for projects with formal funding DOIs.
+
+  - api_source: "project.uuid"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+    notes: >
+      The project UUID is a more stable identifier than the short integer ID,
+      but there is no alternate_id or external_id field on Study to store it.
+
+  - api_source: "project_members[].orcid"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+    notes: >
+      No contributor/PI fields on Study. NamedThing has no creator/contributor slots.
+      This is a schema gap shared with other loaders.
+
+  - api_source: "project_members[].project_role"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+
+  - api_source: "project_members[].institution"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+
+  - api_source: "project_members[].first_name + last_name"
+    schema_class: Study
+    schema_field: "???"
+    schema_field_exists: false
+
+  - api_source: "resource.url"
+    schema_class: Instrument
+    schema_field: "???"
+    schema_field_exists: false
+    notes: >
+      The base Instrument class has no website/url field. BeamlineInstrument has a
+      website: uri field, but CryoEMInstrument and the base Instrument do not.
+      The loader creates a base Instrument (not CryoEMInstrument), so website is
+      unavailable even if added to the subclass.
+
+  - api_source: "datasets[].is_released  (from GET /projects/data/{id})"
+    schema_class: Dataset
+    schema_field: "???"
+    schema_field_exists: false
+    notes: >
+      No embargo or release_status field exists anywhere in the schema.
+      This endpoint is also not called by the loader.
+
+  - api_source: "datasets[].upload_identifier  (from GET /projects/data/{id})"
+    schema_class: ExperimentRun
+    schema_field: experiment_code
+    schema_field_exists: true
+    notes: >
+      This endpoint is not called. If it were, upload_identifier (= transaction_id)
+      would map to experiment_code/id, same as the current search pathway.
+
+  - api_source: "transaction.similarity_score"
+    schema_class: "(none needed)"
+    schema_field: "(none)"
+    schema_field_exists: false
+    notes: "Search relevance score, not a dataset metadata field. Intentionally not mapped."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C. API → SCHEMA: NO Matching Schema Field (Schema Gaps)
+#    (Schema changes needed to represent this data)
+# ─────────────────────────────────────────────────────────────────────────────
+schema_gaps:
+
+  - api_source: "project.started_date"
+    suggested_class: Study
+    suggested_field: start_date
+    field_type: string (date)
+    priority: medium
+    notes: "Project allocation start date. Useful for temporal filtering."
+
+  - api_source: "project.closed_date"
+    suggested_class: Study
+    suggested_field: end_date
+    field_type: string (date)
+    priority: medium
+    notes: "Project allocation end/closure date."
+
+  - api_source: "project.current_status"
+    suggested_class: Study
+    suggested_field: project_status
+    field_type: string or enum
+    priority: low
+    notes: "Values observed: 'started'. Could be an enum (active/closed/pending)."
+
+  - api_source: "project.award_doi"
+    suggested_class: Study
+    suggested_field: award_doi
+    field_type: uri
+    priority: high
+    notes: >
+      Currently stored only on LoaderResult (not persisted in Dataset). Adding
+      award_doi to Study would allow the project funding DOI to survive serialization.
+
+  - api_source: "project.uuid"
+    suggested_class: Study
+    suggested_field: alternate_identifiers  # or external_id
+    field_type: "string multivalued"
+    priority: low
+    notes: "UUID is a more stable reference than the short integer project_id."
+
+  - api_source: "project_members[].orcid + .project_role + .institution + .first_name + .last_name"
+    suggested_class: Study
+    suggested_field: contributors
+    field_type: "Contributor object list (orcid, name, role, institution)"
+    priority: high
+    notes: >
+      No contributor/PI field exists on Study. Could add a lightweight Contributor
+      inline type with: orcid (uri), display_name (string), role (string/enum),
+      institution (string). This would also benefit PDB and SASBDB loaders.
+
+  - api_source: "resource.url"
+    suggested_class: Instrument
+    suggested_field: website
+    field_type: uri
+    priority: medium
+    notes: >
+      BeamlineInstrument already has `website: uri`. The base Instrument class and
+      CryoEMInstrument do not. Should be promoted to Instrument base class, or
+      CryoEMInstrument should inherit it. API provides a relative path
+      (e.g., '/resources/34290') that could be resolved to a full URL.
+
+  - api_source: "datasets[].is_released  (from GET /projects/data/{id})"
+    suggested_class: Dataset
+    suggested_field: is_released
+    field_type: boolean
+    priority: high
+    notes: >
+      No embargo/release status field exists in the schema at any level.
+      is_released (or release_status enum: embargoed/public/restricted) on
+      Dataset would be important for open-data tracking and access control.
+
+  - api_source: "datasets[].total_file_count  (from GET /projects/data/{id})"
+    suggested_class: Dataset
+    suggested_field: file_count
+    field_type: integer
+    priority: low
+    notes: "Summary count; avoids needing to call transaction_info for basic stats."
+
+  - api_source: "datasets[].total_file_size  (from GET /projects/data/{id})"
+    suggested_class: Dataset
+    suggested_field: total_size_bytes
+    field_type: QuantityValue
+    priority: low
+    notes: "Total dataset size in bytes, available without fetching all file metadata."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D. Schema Fields with NO API Source (API limitation)
+#    These exist in the schema and are relevant to cryo-EM but the public
+#    Science Central API does not expose them. They may be available in EPU
+#    XML files inside the .tar archives.
+# ─────────────────────────────────────────────────────────────────────────────
+schema_fields_without_api_source:
+
+  # --- CryoEMInstrument (loader uses base Instrument, never CryoEMInstrument) ---
+  - schema_class: CryoEMInstrument
+    schema_field: accelerating_voltage
+    api_availability: not_in_api
+    potential_source: "EPU XML / reference-data/facilities/emsl.yaml"
+    notes: "300 kV for Krios; static per instrument model. Could be from reference data."
+
+  - schema_class: CryoEMInstrument
+    schema_field: detector_technology
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+
+  - schema_class: CryoEMInstrument
+    schema_field: detector_manufacturer
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+    notes: "Gatan for Krios; static per instrument."
+
+  - schema_class: CryoEMInstrument
+    schema_field: detector_model
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+    notes: "K3 BioQuantum for Krios; static per instrument."
+
+  - schema_class: CryoEMInstrument
+    schema_field: energy_filter_present
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+
+  - schema_class: CryoEMInstrument
+    schema_field: cs
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+    notes: "Spherical aberration value; static per instrument model."
+
+  - schema_class: CryoEMInstrument
+    schema_field: phase_plate
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+
+  - schema_class: CryoEMInstrument
+    schema_field: autoloader_capacity
+    api_availability: not_in_api
+    potential_source: "reference-data/facilities/emsl.yaml"
+
+  - schema_class: CryoEMInstrument
+    schema_field: microscope_software
+    api_availability: partial
+    potential_source: "Inferred from file path subdirectory (epu_session→EPU)"
+    notes: "Currently captured in ExperimentRun.acquisition_software, not on Instrument."
+
+  # --- ExperimentRun (session-level acquisition params — in EPU XML inside .tar) ---
+  - schema_class: ExperimentRun
+    schema_field: magnification
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: calibrated_pixel_size
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: total_dose
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: dose_rate
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: exposure_time_per_frame
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: frames_per_movie
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: defocus_range_min
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: defocus_range_max
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: shots_per_hole
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: camera_binning
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: start_time
+    api_availability: partial
+    potential_source: "transaction.created is upload time, not session start"
+    notes: >
+      transaction.created is when Science Central received the upload, not when the
+      microscope session started. True start_time is in EPU XML.
+
+  - schema_class: ExperimentRun
+    schema_field: end_time
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  - schema_class: ExperimentRun
+    schema_field: daq_system
+    api_availability: partial
+    potential_source: "Inferred from file path (epu_session → EPU DAQ)"
+    notes: "DataAcquisitionSystemEnum field on ExperimentRun is never populated by loader."
+
+  - schema_class: ExperimentRun
+    schema_field: acquisition_software_version
+    api_availability: not_in_api
+    potential_source: "EPU XML inside .tar archive"
+
+  # --- Sample (biological metadata — not in Science Central) ---
+  - schema_class: Sample
+    schema_field: organism
+    api_availability: not_in_api
+    potential_source: "Researcher-provided metadata; not in Science Central"
+
+  - schema_class: Sample
+    schema_field: molecular_weight
+    api_availability: not_in_api
+    potential_source: "Researcher-provided or derived from sequence"
+
+  - schema_class: Sample
+    schema_field: concentration
+    api_availability: not_in_api
+    potential_source: "Researcher-provided"
+
+  - schema_class: Sample
+    schema_field: buffer_composition
+    api_availability: not_in_api
+    potential_source: "Researcher-provided"
+
+  - schema_class: Sample
+    schema_field: protein_name
+    api_availability: partial
+    potential_source: "Partially inferable from sample_value naming convention"
+    notes: >
+      PNCC sample names often encode protein name (e.g., 'T-A-apo' suggests
+      protein 'T-A' in apo state) but this is free-text convention, not structured.
+
+  # --- DataFile ---
+  - schema_class: DataFile
+    schema_field: checksum
+    api_availability: partial
+    potential_source: "SHA1 hash is embedded in filename (e.g., 87ffc243...data.1.tar)"
+    notes: >
+      The SHA1 prefix in PNCC tar filenames is the hash of the EPU session folder,
+      not the individual tar file. Not suitable as a DataFile.checksum (which expects
+      SHA-256 per schema description). Individual file checksums not exposed.
+
+  - schema_class: DataFile
+    schema_field: storage_uri
+    api_availability: not_in_api
+    potential_source: "GET /datasets/request/{tx_id} → Cart.retrieval_url (Globus URL)"
+    notes: >
+      The download cart endpoint would provide a Globus retrieval URL that could
+      populate storage_uri, but this endpoint is not currently called.
+
+  # --- SamplePreparation (cryo grid prep —  not in Science Central) ---
+  - schema_class: SamplePreparation
+    schema_field: "(all fields)"
+    api_availability: not_in_api
+    potential_source: "Researcher-provided; EMSL draft schema has Vitrobot fields"
+    notes: >
+      Grid preparation metadata (Vitrobot settings, blot_time, humidity,
+      plunge_freezing_liquid) is not captured by Science Central at all.
+      These are in the EMSL draft schema (sources/emsl-cryoem-krios.md) but
+      not in the public API.
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUMMARY TABLE
+# ─────────────────────────────────────────────────────────────────────────────
+summary:
+  total_api_fields_identified: 30
+  captured_by_loader: 18
+  loader_gaps_schema_exists: 3          # resource.url (partially), upload_identifier, is_released
+  loader_gaps_schema_missing: 9         # started_date, closed_date, status, award_doi on Study,
+                                        # uuid, project_members (orcid/role/institution/name)
+  schema_gaps_requiring_new_fields: 9   # See schema_gaps section above
+
+  schema_fields_with_no_api_source: 26  # Require EPU XML extraction or reference data lookup
+
+  highest_priority_schema_changes:
+    - "Study.contributors (list of Contributor with orcid, role, institution)"
+    - "Study.award_doi"
+    - "Dataset.is_released (or release_status)"
+    - "Instrument.website promoted to base Instrument class"
+    - "Study.start_date / Study.end_date"
+
+  loader_improvements_no_schema_change_needed:
+    - "Populate Study.start_date / end_date once schema fields added"
+    - "Create CryoEMInstrument instead of base Instrument (enables spec fields)"
+    - "Populate Instrument.website from resource.url (needs schema fix first)"
+    - "Call GET /projects/data/{id} to get is_released per transaction"
+    - "Populate ExperimentRun.daq_system from file path inference"
+
+  blocked_on_api_limitations:
+    - "All session-level cryo-EM params (magnification, dose, defocus, pixel_size)"
+    - "SamplePreparation (grid prep / vitrification parameters)"
+    - "True experiment start/end time"
+    - "Per-file checksums"
+    - "Biological sample metadata (organism, MW, buffer)"

--- a/emsl-dev/api-to-schema-mapping.yaml
+++ b/emsl-dev/api-to-schema-mapping.yaml
@@ -149,101 +149,65 @@ captured:
 
 # ─────────────────────────────────────────────────────────────────────────────
 # B. API → SCHEMA: Field Exists in Schema, NOT Captured by Loader
-#    (Loader gaps — code changes needed, no schema changes)
+#    (Loader gaps — code changes only, no schema changes needed)
+#
+# NOTE: Items where the schema field does NOT exist are in section C (schema_gaps).
 # ─────────────────────────────────────────────────────────────────────────────
 loader_gaps:
 
-  - api_source: "project.started_date"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-    notes: >
-      Study has no start_date field. The NamedThing base has only id/title/description.
-      See schema_gaps below — this needs a schema addition too.
-
-  - api_source: "project.closed_date"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-    notes: "Same as above — no end_date on Study"
-
-  - api_source: "project.current_status"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-    notes: "No project_status or is_active field on Study"
-
-  - api_source: "project.award_doi"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-    notes: >
-      DOI is currently stored on LoaderResult.doi, not on Study. There is no
-      Study.award_doi or Study.doi field. A Study-level DOI field would be useful
-      for projects with formal funding DOIs.
-
-  - api_source: "project.uuid"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-    notes: >
-      The project UUID is a more stable identifier than the short integer ID,
-      but there is no alternate_id or external_id field on Study to store it.
-
-  - api_source: "project_members[].orcid"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-    notes: >
-      No contributor/PI fields on Study. NamedThing has no creator/contributor slots.
-      This is a schema gap shared with other loaders.
-
-  - api_source: "project_members[].project_role"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-
-  - api_source: "project_members[].institution"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-
-  - api_source: "project_members[].first_name + last_name"
-    schema_class: Study
-    schema_field: "???"
-    schema_field_exists: false
-
   - api_source: "resource.url"
-    schema_class: Instrument
-    schema_field: "???"
-    schema_field_exists: false
+    schema_class: BeamlineInstrument
+    schema_field: website
+    schema_field_exists: true
     notes: >
-      The base Instrument class has no website/url field. BeamlineInstrument has a
-      website: uri field, but CryoEMInstrument and the base Instrument do not.
-      The loader creates a base Instrument (not CryoEMInstrument), so website is
-      unavailable even if added to the subclass.
-
-  - api_source: "datasets[].is_released  (from GET /projects/data/{id})"
-    schema_class: Dataset
-    schema_field: "???"
-    schema_field_exists: false
-    notes: >
-      No embargo or release_status field exists anywhere in the schema.
-      This endpoint is also not called by the loader.
+      `website: uri` exists on BeamlineInstrument but NOT on the base Instrument
+      class or CryoEMInstrument. The loader creates a base Instrument (not
+      CryoEMInstrument), so the field is doubly unreachable. Fix requires:
+        1. Promote `website` to base Instrument class in schema (schema change), OR
+        2. Add `website` to CryoEMInstrument AND switch loader to create CryoEMInstrument.
+      API provides a relative path (e.g., '/resources/34290') that would need
+      resolving to a full URL before storing.
 
   - api_source: "datasets[].upload_identifier  (from GET /projects/data/{id})"
     schema_class: ExperimentRun
     schema_field: experiment_code
     schema_field_exists: true
     notes: >
-      This endpoint is not called. If it were, upload_identifier (= transaction_id)
-      would map to experiment_code/id, same as the current search pathway.
+      This endpoint is not called by the loader. If it were, upload_identifier
+      (= transaction_id) would map to experiment_code/id, same as the current
+      search pathway. Low priority since the current path already captures this.
 
-  - api_source: "transaction.similarity_score"
-    schema_class: "(none needed)"
-    schema_field: "(none)"
-    schema_field_exists: false
-    notes: "Search relevance score, not a dataset metadata field. Intentionally not mapped."
+  - api_source: "files[].path (subdir inference)"
+    schema_class: ExperimentRun
+    schema_field: daq_system
+    schema_field_exists: true
+    notes: >
+      ExperimentRun.daq_system (DataAcquisitionSystemEnum) exists in schema but
+      is never populated by the loader. The acquisition_software inference already
+      identifies EPU/SerialEM/Leginon from the file path — the same logic could
+      set daq_system (e.g., epu_session → DAQ_EPU). One-line loader fix.
+
+  - api_source: "file.name (SHA1 prefix)"
+    schema_class: DataFile
+    schema_field: checksum
+    schema_field_exists: true
+    notes: >
+      DataFile.checksum exists in schema (described as SHA-256). The SHA1 prefix
+      embedded in PNCC tar filenames (e.g., '87ffc243...data.1.tar') is the hash
+      of the EPU session folder, not a per-file checksum. Cannot be used as-is.
+      Individual file checksums are not exposed by the API. Loader gap: field
+      can't be populated until EMSL provides per-file checksums.
+
+  - api_source: "GET /datasets/request/{tx_id} → Cart.retrieval_url"
+    schema_class: DataFile
+    schema_field: storage_uri
+    schema_field_exists: true
+    notes: >
+      DataFile.storage_uri exists in schema (range: string, for S3/Globus URIs).
+      The download cart endpoint returns a retrieval URL that could populate this
+      field. The loader does call the cart endpoint (for EPU extraction) but does
+      not store the retrieval URL on DataFile. Would require JWT and cart creation
+      per transaction.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -334,6 +298,24 @@ schema_gaps:
     priority: low
     notes: "Total dataset size in bytes, available without fetching all file metadata."
 
+  - api_source: "EPU XML StartDateTime (inside .tar archive)"
+    suggested_class: ExperimentRun
+    suggested_field: start_time
+    field_type: string (datetime)
+    priority: medium
+    notes: >
+      ExperimentRun has experiment_date (string, currently set to upload time) but
+      no dedicated start_time or end_time fields. EPU XML contains a StartDateTime
+      element with the true microscope session start. Needs a new field on
+      ExperimentRun and a parser update.
+
+  - api_source: "EPU XML EndDateTime (inside .tar archive)"
+    suggested_class: ExperimentRun
+    suggested_field: end_time
+    field_type: string (datetime)
+    priority: low
+    notes: "EPU XML may contain an EndDateTime. Needs new schema field and parser update."
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # D. Schema Fields with NO API Source (API limitation)
@@ -395,79 +377,110 @@ schema_fields_without_api_source:
     notes: "Currently captured in ExperimentRun.acquisition_software, not on Instrument."
 
   # --- ExperimentRun (session-level acquisition params — in EPU XML inside .tar) ---
+  # Fields marked epu_extracted are already populated by the loader when --extract-epu
+  # is passed and the download cart stages successfully.
+  # Fields marked not_in_api/epu_not_extracted are genuine remaining gaps.
+
   - schema_class: ExperimentRun
     schema_field: magnification
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML inside .tar archive — XPaths: .//Magnification, .//NominalMagnification"
 
   - schema_class: ExperimentRun
     schema_field: calibrated_pixel_size
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//PixelSize (meters, converted to Å/pixel)"
 
   - schema_class: ExperimentRun
     schema_field: total_dose
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//TotalExposureDose or computed from DosePerFrame × frames"
 
   - schema_class: ExperimentRun
     schema_field: dose_rate
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//DoseRate"
 
   - schema_class: ExperimentRun
     schema_field: exposure_time_per_frame
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//ExposureTime (seconds, converted to ms)"
 
   - schema_class: ExperimentRun
     schema_field: frames_per_movie
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//NumberOffractions, .//FramesPerExposure"
+
+  - schema_class: ExperimentRun
+    schema_field: defocus_target
+    api_availability: not_in_api
+    epu_extracted: true
+    potential_source: "EPU XML — .//TargetDefocus (meters, converted to µm)"
 
   - schema_class: ExperimentRun
     schema_field: defocus_range_min
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//MinDefocus (meters, converted to µm)"
 
   - schema_class: ExperimentRun
     schema_field: defocus_range_max
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//MaxDefocus (meters, converted to µm)"
 
   - schema_class: ExperimentRun
     schema_field: shots_per_hole
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//ShotsPerHole"
 
   - schema_class: ExperimentRun
     schema_field: camera_binning
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//Binning, .//CameraBinning"
 
   - schema_class: ExperimentRun
-    schema_field: start_time
-    api_availability: partial
-    potential_source: "transaction.created is upload time, not session start"
-    notes: >
-      transaction.created is when Science Central received the upload, not when the
-      microscope session started. True start_time is in EPU XML.
-
-  - schema_class: ExperimentRun
-    schema_field: end_time
+    schema_field: holes_per_group
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//HolesPerGroup"
 
   - schema_class: ExperimentRun
-    schema_field: daq_system
-    api_availability: partial
-    potential_source: "Inferred from file path (epu_session → EPU DAQ)"
-    notes: "DataAcquisitionSystemEnum field on ExperimentRun is never populated by loader."
+    schema_field: stage_tilt
+    api_availability: not_in_api
+    epu_extracted: true
+    potential_source: "EPU XML — .//StageTilt (degrees)"
 
   - schema_class: ExperimentRun
     schema_field: acquisition_software_version
     api_availability: not_in_api
-    potential_source: "EPU XML inside .tar archive"
+    epu_extracted: true
+    potential_source: "EPU XML — .//Version, .//SoftwareVersion, .//ApplicationVersion"
+
+  - schema_class: ExperimentRun
+    schema_field: start_time
+    api_availability: partial
+    epu_extracted: false
+    potential_source: "EPU XML contains session StartDateTime; not yet parsed by loader"
+    notes: >
+      transaction.created is upload time (Science Central), not microscope session start.
+      EPU XML has a StartDateTime element but the parser does not extract it yet.
+      schema gap: ExperimentRun has experiment_date (string) but no dedicated start_time field.
+
+  - schema_class: ExperimentRun
+    schema_field: end_time
+    api_availability: not_in_api
+    epu_extracted: false
+    potential_source: "EPU XML may contain EndDateTime; not parsed by loader"
+    notes: "Schema gap: no end_time field on ExperimentRun. Needs schema addition and parser update."
 
   # --- Sample (biological metadata — not in Science Central) ---
   - schema_class: Sample
@@ -498,23 +511,8 @@ schema_fields_without_api_source:
       PNCC sample names often encode protein name (e.g., 'T-A-apo' suggests
       protein 'T-A' in apo state) but this is free-text convention, not structured.
 
-  # --- DataFile ---
-  - schema_class: DataFile
-    schema_field: checksum
-    api_availability: partial
-    potential_source: "SHA1 hash is embedded in filename (e.g., 87ffc243...data.1.tar)"
-    notes: >
-      The SHA1 prefix in PNCC tar filenames is the hash of the EPU session folder,
-      not the individual tar file. Not suitable as a DataFile.checksum (which expects
-      SHA-256 per schema description). Individual file checksums not exposed.
-
-  - schema_class: DataFile
-    schema_field: storage_uri
-    api_availability: not_in_api
-    potential_source: "GET /datasets/request/{tx_id} → Cart.retrieval_url (Globus URL)"
-    notes: >
-      The download cart endpoint would provide a Globus retrieval URL that could
-      populate storage_uri, but this endpoint is not currently called.
+  # NOTE: DataFile.checksum and DataFile.storage_uri were previously listed here
+  # but both fields EXIST in the schema — they belong in section B (loader_gaps).
 
   # --- SamplePreparation (cryo grid prep —  not in Science Central) ---
   - schema_class: SamplePreparation
@@ -534,30 +532,63 @@ schema_fields_without_api_source:
 summary:
   total_api_fields_identified: 30
   captured_by_loader: 18
-  loader_gaps_schema_exists: 3          # resource.url (partially), upload_identifier, is_released
-  loader_gaps_schema_missing: 9         # started_date, closed_date, status, award_doi on Study,
-                                        # uuid, project_members (orcid/role/institution/name)
-  schema_gaps_requiring_new_fields: 9   # See schema_gaps section above
 
-  schema_fields_with_no_api_source: 26  # Require EPU XML extraction or reference data lookup
+  # B: schema field exists, loader doesn't populate it (no schema change needed)
+  loader_gaps_schema_exists: 5
+    # resource.url → BeamlineInstrument.website (needs class promotion too)
+    # datasets[].upload_identifier → ExperimentRun.experiment_code (low priority)
+    # files[].path → ExperimentRun.daq_system (one-line fix)
+    # file.name (SHA1) → DataFile.checksum (field exists; SHA1 wrong hash type)
+    # Cart.retrieval_url → DataFile.storage_uri (field exists; JWT + cart needed)
+
+  # C: API field has no matching schema field anywhere (schema change required)
+  schema_gaps_requiring_new_fields: 11
+    # Study.start_date (from project.started_date)
+    # Study.end_date (from project.closed_date)
+    # Study.project_status (from project.current_status)
+    # Study.award_doi (from project.award_doi)
+    # Study.alternate_identifiers (from project.uuid)
+    # Study.contributors (from project_members[]: orcid, role, institution, name)
+    # Dataset.is_released (from datasets[].is_released)
+    # Dataset.file_count (from datasets[].total_file_count)
+    # Dataset.total_size_bytes (from datasets[].total_file_size)
+    # ExperimentRun.start_time (in EPU XML StartDateTime; experiment_date is upload time)
+    # ExperimentRun.end_time (in EPU XML EndDateTime)
+    # NOTE: resource.url → Instrument.website also requires schema change (class promotion)
+    #       but is listed in B because the field exists on BeamlineInstrument
+
+  # D: schema fields with no public API source
+  schema_fields_with_no_api_source: 24  # Require EPU XML extraction or reference data
+    # Of these, 14 are already extracted by the loader (--extract-epu flag):
+    #   magnification, calibrated_pixel_size, camera_binning, exposure_time_per_frame,
+    #   frames_per_movie, total_dose, dose_rate, defocus_target, defocus_range_min,
+    #   defocus_range_max, shots_per_hole, holes_per_group, stage_tilt,
+    #   acquisition_software_version
+    # Remaining 10 still require work:
+    #   CryoEMInstrument fields (8): accelerating_voltage, detector_technology,
+    #     detector_manufacturer, detector_model, energy_filter_present, cs,
+    #     phase_plate, autoloader_capacity — all in reference-data/facilities/emsl.yaml
+    #   Sample (5): organism, molecular_weight, concentration, buffer_composition, protein_name
+    #   SamplePreparation: all fields
+    # NOTE: DataFile.checksum and DataFile.storage_uri moved to section B (schema fields exist)
 
   highest_priority_schema_changes:
     - "Study.contributors (list of Contributor with orcid, role, institution)"
     - "Study.award_doi"
     - "Dataset.is_released (or release_status)"
-    - "Instrument.website promoted to base Instrument class"
+    - "Instrument.website promoted from BeamlineInstrument to base Instrument class"
     - "Study.start_date / Study.end_date"
 
   loader_improvements_no_schema_change_needed:
-    - "Populate Study.start_date / end_date once schema fields added"
-    - "Create CryoEMInstrument instead of base Instrument (enables spec fields)"
-    - "Populate Instrument.website from resource.url (needs schema fix first)"
-    - "Call GET /projects/data/{id} to get is_released per transaction"
-    - "Populate ExperimentRun.daq_system from file path inference"
+    - "Populate ExperimentRun.daq_system from file path inference (one-line fix)"
+    - "Create CryoEMInstrument instead of base Instrument (enables all spec fields)"
+    - "Merge reference-data/facilities/emsl.yaml for CryoEMInstrument spec fields"
+    - "Populate Instrument.website from resource.url (requires schema promotion first)"
+    - "Call GET /projects/data/{id} to get is_released per transaction (requires schema addition)"
 
   blocked_on_api_limitations:
-    - "All session-level cryo-EM params (magnification, dose, defocus, pixel_size)"
-    - "SamplePreparation (grid prep / vitrification parameters)"
-    - "True experiment start/end time"
-    - "Per-file checksums"
-    - "Biological sample metadata (organism, MW, buffer)"
+    - "Session-level cryo-EM params: available via EPU XML (--extract-epu), blocked only on tape staging"
+    - "SamplePreparation (grid prep / vitrification parameters) — not in API or EPU XML"
+    - "True session start_time / end_time — EPU XML has StartDateTime but needs schema field + parser update"
+    - "Per-file checksums — SHA1 in filename is folder hash, not file checksum"
+    - "Biological sample metadata (organism, MW, buffer) — researcher-provided only"

--- a/emsl-dev/metadata-sources.yaml
+++ b/emsl-dev/metadata-sources.yaml
@@ -1,0 +1,514 @@
+# EMSL CryoEM Metadata Sources: Acquisition, Instrument, and Sample
+#
+# For an end-to-end pipeline the public Science Central API is only
+# the entry point. This document catalogues every known or potential
+# data source for the three categories of metadata the API does not expose,
+# with assessment of feasibility for each.
+#
+# Data flow at EMSL (from activity2-presentations-summary.md):
+#   Sample → Vitrification → Krios → KriosGPU → TAHOMA → Science Central
+#                                                       → AURORA (archive)
+#                                                       → BER Lakehouse
+#
+# Prepared: 2026-04-03
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. ACQUISITION / SESSION METADATA
+#    Fields: magnification, calibrated_pixel_size, total_dose, dose_rate,
+#            exposure_time_per_frame, frames_per_movie, defocus_range,
+#            shots_per_hole, holes_per_group, camera_binning, astigmatism_target,
+#            coma, stage_tilt, start_time, end_time, acquisition_software_version
+# ─────────────────────────────────────────────────────────────────────────────
+acquisition_metadata_sources:
+
+  # ── AUTHENTICATION NOTE ──────────────────────────────────────────────────
+  # All four endpoints currently used by the loader work WITHOUT authentication:
+  #   POST /datasets/by_sample_name   → public
+  #   GET  /projects/{id}             → public
+  #   GET  /resources/{id}            → public
+  #   GET  /datasets/transaction_info/{tx_id} → public
+  #
+  # Downloading actual data files requires a JWT bearer token. The token is
+  # obtained via the EMSL client (not yet automated). This blocks Phase 2
+  # (tar extraction) until a token strategy is decided:
+  #
+  #   Option A — Manual injection: user generates token via EMSL client,
+  #              passes it as env var (EMSL_JWT) or config entry. Loader reads
+  #              it and adds "Authorization: Bearer {token}" header only for
+  #              download-cart calls. Token has a finite lifetime.
+  #
+  #   Option B — Config-file token: token stored in ~/.emsl_token or a local
+  #              config file (not committed). Loader reads on demand.
+  #
+  #   Option C — Token refresh automation (deferred): automate client credential
+  #              flow when the team is ready to productionize.
+  #
+  # Implication: Phase 1 items (reference-data merge, CryoEMInstrument upgrade,
+  # resources/grouping call) are completely unblocked — no JWT needed.
+  # Phase 2 (EPU XML extraction) is blocked until one of the above options is
+  # chosen. Phase 2 can still be designed and tested with a manually provided token.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - source: EPU Session XML Files
+    location_in_pipeline: "Inside .tar archives on Science Central (path: .../epu_session/*.xml)"
+    format: "XML (EPU session format)"
+    auth_required: true
+    auth_note: "JWT bearer token required for GET /datasets/request/{tx_id} and file download"
+    access_method: >
+      Download .tar archives via Science Central download-cart API
+      (GET /datasets/request/{tx_id} → retrieval_url, requires JWT),
+      extract specific XML files without downloading entire dataset.
+    available_fields:
+      - magnification
+      - calibrated_pixel_size (Å/pixel)
+      - camera_binning
+      - exposure_time_per_frame (ms)
+      - frames_per_movie
+      - total_dose (e-/Å²)
+      - dose_rate (e-/pixel/s)
+      - defocus_target, defocus_range_min, defocus_range_max
+      - astigmatism_target
+      - shots_per_hole
+      - holes_per_group
+      - stage_tilt
+      - acquisition_software_version
+      - session.date (true collection start, not upload time)
+    feasibility: high
+    notes: >
+      EPU writes a session-level .dm or .xml file that contains all acquisition
+      parameters set by the operator before collection starts. These are inside
+      the tar archives but are small metadata files. A targeted extraction
+      (list tar → find *Session*.xml → extract just that file) avoids downloading
+      100s of GB per transaction. The EMSL draft schema (sources/emsl-cryoem-krios.md)
+      confirms these fields are "already part of EMSL's automated metadata capture
+      in YAML format" (green-highlighted fields). EPU also writes per-hole .xml
+      files with per-image defocus and beam shift — more granular than session-level.
+    implementation_sketch: >
+      1. Call GET /datasets/request/{tx_id} to create download cart.
+      2. Use Globus or direct HTTP to fetch only the EPU session .xml or _session.yaml.
+      3. Parse XML/YAML → populate ExperimentRun acquisition fields.
+      4. Optionally parse per-hole XMLs for Image2D/Movie-level metadata.
+    contacts: "August George, James Evans (PNNL) — have confirmed automated YAML capture"
+
+  - source: EPU Session Summary YAML
+    location_in_pipeline: "KriosGPU → TAHOMA; separate from raw .tar"
+    format: YAML
+    access_method: >
+      EMSL generates a session summary YAML at the end of each EPU collection.
+      According to the activity2 slides, this is part of the 'data archival metadata'
+      category. It is unclear if this YAML is included in the Science Central
+      transaction or archived separately in AURORA. Requires verification with
+      James Evans / August George at PNNL.
+    available_fields:
+      - All session-level acquisition parameters (same as EPU XML)
+      - Possibly summary statistics (total movies collected, estimated dose)
+    feasibility: medium
+    notes: >
+      If this YAML file is present inside the .tar or as a separate transaction
+      file, it may be easier to parse than raw EPU XML. Needs confirmation that
+      it is part of the Science Central transaction payload.
+
+  - source: SerialEM .mdoc Files
+    location_in_pipeline: "Inside .tar archives (path: .../serialem/*.mdoc)"
+    format: "MDOC (plain text key=value)"
+    access_method: "Same Globus/cart download approach as EPU XML"
+    available_fields:
+      - magnification
+      - pixel_size
+      - exposure_time
+      - total_dose
+      - defocus
+      - stage_tilt (critical for tomography)
+      - tilt_series metadata
+      - timestamp per image
+    feasibility: high
+    notes: >
+      When acquisition_software is SerialEM (inferred from 'serialem' subdir in
+      path), .mdoc files are the metadata source. Well-documented format. Libraries
+      exist in Python (e.g., mdocfile, seriaEM-mdoc-parser).
+    scope: "Relevant for tomography (#3 priority) and some SPA sessions"
+
+  - source: Leginon Database / .xml
+    location_in_pipeline: "Inside .tar archives (path: .../leginon/)"
+    format: XML / SQLite
+    access_method: "Tar extraction"
+    available_fields:
+      - acquisition parameters
+      - session metadata
+    feasibility: low
+    notes: >
+      Leginon is used at some facilities but not confirmed at PNCC. Lower priority
+      than EPU/SerialEM for EMSL cryo-EM.
+
+  - source: EMSL AURORA Archive (internal)
+    location_in_pipeline: "AURORA raw & processed data archive (internal PNNL system)"
+    format: Unknown (likely HDF5 or YAML)
+    access_method: "Not publicly accessible; requires PNNL internal access or collaboration"
+    available_fields:
+      - All of the above plus processed data outputs
+    feasibility: low (requires internal partnership)
+    notes: >
+      AURORA is EMSL's internal archival system downstream of Science Central.
+      Not exposed via the public API. Would require a direct integration agreement
+      with PNNL. Long-term option for richer metadata access.
+
+  - source: KriosGPU Server (local processing)
+    location_in_pipeline: "On-microscope GPU server; runs pre-processing (patch motion, CTF)"
+    format: "STAR files, log files"
+    access_method: "Not publicly accessible"
+    available_fields:
+      - Per-micrograph CTF estimates (defocus_u, defocus_v, astigmatism)
+      - Motion correction statistics (drift_total)
+    feasibility: low
+    notes: >
+      KriosGPU output may eventually flow into Science Central or AURORA but is
+      not currently accessible via the public API.
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. INSTRUMENT METADATA
+#    Fields: accelerating_voltage, cs, detector_model, detector_manufacturer,
+#            detector_mode, detector_technology, energy_filter_present,
+#            energy_filter_model, energy_filter_slit_width, phase_plate,
+#            autoloader_capacity, pixel_size_physical, microscope_software,
+#            imaging_mode, c2_aperture, cs_corrector
+# ─────────────────────────────────────────────────────────────────────────────
+instrument_metadata_sources:
+
+  - source: reference-data/facilities/emsl.yaml (in-repo)
+    location_in_pipeline: "Static file in lambda-ber-schema repository"
+    format: YAML (lambda-ber schema format)
+    access_method: "Load at ETL time; look up by resource_id or resource name"
+    available_fields:
+      - accelerating_voltage (300 kV for Krios)
+      - detector_technology (direct_electron_detector)
+      - detector_manufacturer (Gatan)
+      - detector_model (K3 BioQuantum)
+      - detector_mode (counting)
+      - energy_filter_present (true)
+      - energy_filter_make (Gatan)
+      - energy_filter_model (BioQuantum)
+      - autoloader_capacity (12)
+      - phase_plate (true)
+      - cs_corrector (false)
+      - manufacturer, model, installation_date, current_status
+    feasibility: high (immediately available)
+    notes: >
+      This file already exists and has correct data for the Krios G3i and Aquilos 2.
+      The loader currently IGNORES it entirely. Reconciliation logic is needed to
+      match Science Central resource_id (e.g., 34290) to the static record
+      (lambdaber:instrument_emsl_krios_g3i) by name pattern matching (e.g.,
+      'Krios' in resource.name → use Krios reference record for spec fields).
+      The loader should:
+        1. Create a CryoEMInstrument (not base Instrument)
+        2. Look up the matching reference record by name/type
+        3. Merge spec fields from reference record with dynamic fields from API
+           (id, title, display_name, location, active, available_hours)
+    current_status: >
+      KNOWN BUG: resource.active=false for all observed live instruments.
+      The reference data has current_status=operational. The static record
+      should override the API's active flag for status.
+
+  - source: Science Central /resources/all or /resources/active
+    location_in_pipeline: "GET /resources/all  (not currently called)"
+    format: JSON (Resources schema)
+    access_method: "Simple GET, no auth required"
+    available_fields:
+      - id, name, display_name, location, active, available_hours, url
+      - (same as /resources/{id} but full list in one call)
+    feasibility: high
+    notes: >
+      Calling /resources/all once at startup and caching the result would let the
+      loader resolve all instrument names and IDs without per-transaction calls.
+      More importantly, /resources/grouping returns a group field that could
+      classify instruments (e.g., PNCC Krios group) without name-regex heuristics.
+
+  - source: Science Central /resources/grouping
+    location_in_pipeline: "GET /resources/grouping  (not currently called)"
+    format: JSON
+    access_method: "Simple GET, no auth required"
+    available_fields:
+      - resource_id, resource_uuid, resource_name, group
+    feasibility: high
+    notes: >
+      The group field would let us map resource IDs to instrument families
+      (e.g., 'PNCC Krios' group → CryoEMInstrument with 300kV) without
+      fragile regex over resource names. Should replace or supplement the
+      current _infer_instrument_category regex.
+
+  - source: EMSL Website / BER Structural Biology Portal
+    location_in_pipeline: "Static web pages; scraped or curated manually"
+    access_method: "Manual curation → update reference-data/facilities/emsl.yaml"
+    available_fields:
+      - Full instrument specifications for all EMSL cryo-EM instruments
+      - Instrument upgrades (e.g., new detector model after K3)
+    feasibility: high (manual curation)
+    notes: >
+      The BER Structural Biology portal (berstructuralbioportal.org) lists EMSL
+      instrument specs. Reference data should be updated when instruments are
+      upgraded or new instruments added (e.g., Arctica, Aquilos, potential new
+      instruments). This is the ground-truth source for static specs.
+    url: "https://www.berstructuralbioportal.org/cryogenic-transmission-electron-microscopy-at-emsl/"
+
+  - source: EMDB / EMPIAR instrument records (for deposited datasets only)
+    location_in_pipeline: "External repository; available after publication"
+    format: "mmCIF / XML"
+    access_method: "EMDB REST API or EMPIAR file download"
+    available_fields:
+      - All mmCIF _em_imaging fields (voltage, Cs, magnification, mode)
+      - Detector specs
+    feasibility: medium (only for deposited/published datasets)
+    notes: >
+      For transactions that have been deposited to EMDB/PDB, the mmCIF file
+      contains complete instrument specs. This is a retroactive enrichment
+      path — useful for populating historical records but not real-time ingestion.
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. USER-PROVIDED / SAMPLE METADATA
+#    Fields (biological): organism, molecular_weight, concentration,
+#            buffer_composition, protein_name, construct, expression_system,
+#            mutations, oligomeric_state, ligand
+#    Fields (grid prep): grid.support, grid.material, glow_discharge params,
+#            vitrification.method, blot_time, blot_force, humidity, temperature
+# ─────────────────────────────────────────────────────────────────────────────
+sample_metadata_sources:
+
+  - source: EMSL User Proposal / Project Application
+    location_in_pipeline: "Submitted before experiment; stored in EMSL project management system"
+    format: "Structured form (web portal) or PDF"
+    access_method: >
+      Not in public API. Accessible only via:
+        a) EMSL staff export (requires collaboration with James Evans / user contact)
+        b) A future Science Central API extension (would require PNNL dev work)
+    available_fields:
+      - Sample name, organism, protein description
+      - Experimental objectives
+      - PI/team information (overlaps with project_members[] already in API)
+    feasibility: low (not in public API)
+    notes: >
+      The most complete source of biological context, but locked in the internal
+      user proposal system. Not feasible for automated pipeline without PNNL
+      internal access.
+
+  - source: Science Central Project Metadata (partial)
+    location_in_pipeline: "GET /projects/{id} — already called by loader"
+    format: JSON
+    access_method: "Already called; captures title, abstract, members"
+    available_fields:
+      - project.title (encodes protein/research context in free text)
+      - project.abstract (biological description)
+      - project_members[].orcid (PI identity)
+    feasibility: high (already available)
+    notes: >
+      The project abstract often describes the biological system (organism, protein
+      family, disease context) in prose. NLP extraction could supplement structured
+      fields. This is currently underused — description is captured but not parsed.
+
+  - source: Session Summary YAML / Notes File
+    location_in_pipeline: >
+      Inside transaction .tar, typically a notes.txt or session_summary.yaml file.
+      Observed: notes.txt alongside .data.*.tar files in epu_session/ directory.
+    format: "Plain text or YAML"
+    access_method: "Tar extraction (same approach as EPU XML)"
+    available_fields:
+      - Free-text operator notes (variable)
+      - Sometimes: protein name, buffer, concentration, grid type
+      - EPU session YAML may contain: sample description, preparation notes
+    feasibility: medium
+    notes: >
+      Quality and completeness depends entirely on operator discipline. Some
+      sessions have rich notes, others have none. The notes.txt observed in
+      transaction 3736677 is an example — content unknown without downloading.
+      This is the "yellow highlighted" category in the EMSL draft schema
+      (manually captured, available in session files).
+
+  - source: EMSL-Provided Metadata Template (proposed)
+    location_in_pipeline: "User fills out before/after session; submitted to Science Central"
+    format: "YAML or structured form"
+    access_method: "Could be a separate Science Central endpoint or uploaded as a metadata file"
+    available_fields:
+      - All biological sample fields (organism, MW, buffer, concentration, construct)
+      - Grid preparation fields (grid type, vitrification params)
+    feasibility: medium-high (requires PNNL process change)
+    notes: >
+      The EMSL draft schema document (sources/emsl-cryoem-krios.md) was written
+      specifically to define what should be captured. James Evans and Trevor Moser
+      at PNNL are the contacts for implementing a structured metadata submission
+      workflow. This is the most complete long-term solution:
+        1. EMSL creates a structured submission form or YAML template
+        2. User fills it out per session
+        3. Template is uploaded as a metadata file alongside the .tar
+        4. Our loader parses it directly
+      This aligns with the EMPIAR/EMDB deposition requirements EMSL already tracks.
+
+  - source: EMPIAR / EMDB (post-deposition)
+    location_in_pipeline: "External repository; available after publication"
+    format: "JSON (EMPIAR API), mmCIF (EMDB)"
+    access_method: "Public REST APIs"
+    available_fields:
+      - Organism, taxid
+      - Sample description, MW
+      - Buffer composition (sometimes)
+      - Grid type, vitrification method
+      - All mmCIF biological assembly info
+    feasibility: medium (published datasets only)
+    notes: >
+      EMPIAR records contain sample and acquisition metadata for deposited raw data.
+      EMDB entries have full biological and instrument metadata. For datasets that
+      have been deposited, these are authoritative and complete. Cross-linking a
+      Science Central transaction to its EMPIAR/EMDB entry (via EMDB ID in notes
+      or project abstract) would close the majority of schema gaps retroactively.
+      The PDBLoader already demonstrates this pattern.
+
+  - source: UniProt / PDB (for protein target enrichment)
+    location_in_pipeline: "External knowledge base; cross-referenced by protein name or ID"
+    format: "JSON (UniProt REST API)"
+    access_method: "Public REST API"
+    available_fields:
+      - organism, taxid, molecular_weight
+      - sequence, sequence_length
+      - protein family, function, disease associations
+      - Structural features, PTMs
+    feasibility: medium
+    notes: >
+      The project abstract and sample_value often encode the protein name
+      (e.g., 'PARP enzymes', 'Yo1'). NLP parsing → UniProt text search → ID
+      resolution could populate Sample.organism, Sample.molecular_weight,
+      Sample.protein_name, and even functional annotation fields.
+      This is the approach used by PDBLoader (which fetches from RCSB by PDB ID).
+
+  - source: Operator-Provided YAML Sidecar (future)
+    location_in_pipeline: "Uploaded alongside data collection session"
+    format: "YAML following lambda-ber-schema Sample / SamplePreparation classes"
+    access_method: >
+      Operator uploads a small YAML conforming to the schema before/after session.
+      Science Central stores it as a regular transaction file (alongside .tar).
+      Our loader detects and parses it.
+    available_fields: "All Sample and SamplePreparation fields"
+    feasibility: medium (requires operator adoption)
+    notes: >
+      Lightest-weight approach: no new Science Central features needed. Operator
+      uploads a YAML that uses our schema directly. The loader looks for a file
+      matching '*metadata*.yaml' or 'lambda-ber-*.yaml' in the transaction files
+      and parses it if present. This is how the existing data.yaml in the repo root works.
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RECOMMENDED IMPLEMENTATION PHASES
+# ─────────────────────────────────────────────────────────────────────────────
+implementation_roadmap:
+
+  phase_1_immediate:
+    description: "No new API calls, no external dependencies — use what we already have"
+    items:
+      - action: "Upgrade loader to create CryoEMInstrument instead of base Instrument"
+        benefit: "Enables all CryoEMInstrument spec fields to be populated"
+        source: reference-data/facilities/emsl.yaml
+        effort: low
+
+      - action: "Merge reference-data/facilities/emsl.yaml into loader by name matching"
+        benefit: "Populates accelerating_voltage, detector_model, energy_filter, Cs, etc."
+        source: reference-data/facilities/emsl.yaml
+        effort: low
+        notes: "Match 'Krios' in resource.name → emsl_krios_g3i reference record"
+
+      - action: "Fix current_status: override active=false with reference record status"
+        benefit: "Instruments show as operational instead of offline"
+        source: reference-data/facilities/emsl.yaml
+        effort: trivial
+
+      - action: "Add /resources/grouping call for instrument classification"
+        benefit: "Replaces fragile regex inference for instrument_category"
+        source: Science Central API
+        effort: low
+
+      - action: "Populate ExperimentRun.daq_system from file path inference"
+        benefit: "epu_session → EPU DAQ; already inferrable"
+        source: transaction file paths
+        effort: trivial
+
+  phase_2_tar_extraction:
+    description: "Extract EPU XML / session YAML from inside .tar without full download"
+    blocked_by: "JWT authentication — requires EMSL bearer token for download-cart API"
+    unblock_options:
+      - "Option A: EMSL_JWT env var, user generates token via EMSL client before running loader"
+      - "Option B: Token stored in local config file (e.g., ~/.emsl_token), read on demand"
+      - "Option C: Automate token refresh (deferred — not yet needed)"
+    items:
+      - action: "Add optional JWT support to EMSLLoader: read EMSL_JWT env var, attach as Authorization header only for download-cart calls"
+        benefit: "Enables Phase 2 when token is provided; silently skips tar extraction when not"
+        effort: trivial
+        notes: "No impact on existing public-API calls — auth header only added for /datasets/request/ and file download URLs"
+
+      - action: "Implement targeted .tar file extraction via Globus or HTTP range request"
+        benefit: "Unlocks: magnification, pixel_size, dose, defocus_range, binning, shots_per_hole"
+        source: "EPU XML / session YAML inside .tar"
+        effort: medium
+        notes: >
+          Key technique: use 'tar -t' (list) to find metadata files, then extract
+          only those. EPU puts EpuSession.dm / GridSquare.dm / FoilHole.xml
+          at the start of the archive. HTTP range requests against the Globus
+          retrieval_url might allow partial extraction without full download.
+          Needs testing with actual EMSL .tar files.
+
+      - action: "Parse EPU session XML into ExperimentRun fields"
+        benefit: "Fully populates ExperimentRun acquisition metadata"
+        source: "EPU XML"
+        effort: medium
+        notes: "Python libraries: lxml, xml.etree. Well-documented EPU XML format."
+
+      - action: "Parse notes.txt / session_summary YAML"
+        benefit: "Captures operator-entered sample context"
+        source: "Session notes file"
+        effort: low (once tar extraction is in place)
+
+  phase_3_schema_additions:
+    description: "Schema changes to capture data that has no home yet"
+    items:
+      - action: "Add Study.contributors (orcid, role, institution)"
+        benefit: "Captures PI ORCID and institution from project_members[]"
+        effort: medium (schema + loader change)
+
+      - action: "Add Study.award_doi, Study.start_date, Study.end_date"
+        benefit: "Captures project funding and temporal metadata"
+        effort: low (schema + loader change)
+
+      - action: "Add Dataset.is_released"
+        benefit: "Tracks embargo/public release status"
+        effort: low (schema + loader change)
+        requires_new_api_call: "GET /projects/data/{project_id}"
+
+      - action: "Promote Instrument.website to base Instrument class"
+        benefit: "Captures resource.url from API"
+        effort: trivial (schema change only)
+
+  phase_4_user_metadata:
+    description: "Structured sample and grid prep metadata — requires PNNL collaboration"
+    items:
+      - action: "Define lambda-ber YAML metadata template for sample/grid prep"
+        benefit: "Operators can submit structured metadata alongside data"
+        effort: medium (template design + documentation)
+        contacts: "James Evans, Trevor Moser (PNNL)"
+
+      - action: "Add NLP extraction of organism/protein from project.abstract"
+        benefit: "Partially populates Sample.organism, protein_name from free text"
+        effort: high
+        notes: "Use UniProt text API or simple regex for known protein families"
+
+      - action: "Add EMPIAR cross-link enrichment for deposited datasets"
+        benefit: "Retroactively fills all biological metadata from EMPIAR records"
+        effort: medium
+        notes: "Detect EMPIAR ID in project abstract (regex for 'EMPIAR-XXXXX')"
+
+  phase_5_internal_access:
+    description: "Requires PNNL internal system access — partnership decision"
+    items:
+      - action: "Direct AURORA archive access or Science Central internal API"
+        benefit: "Full metadata without tar extraction"
+        effort: high
+        contacts: "James Evans, August George (PNNL)"
+
+      - action: "Science Central metadata submission form integration"
+        benefit: "Structured biological/grid-prep metadata at submission time"
+        effort: high (requires PNNL platform development)

--- a/emsl-dev/swagger.json
+++ b/emsl-dev/swagger.json
@@ -1,0 +1,1441 @@
+{
+    "swagger": "2.0",
+    "basePath": "/external",
+    "paths": {
+        "/datasets/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_dataset_limit_api",
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/by_sample/{sample_name}": {
+            "parameters": [
+                {
+                    "description": "Sample name to search for",
+                    "name": "sample_name",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Sample%20Name%20Search%20Result"
+                        }
+                    }
+                },
+                "summary": "Quick search for datasets by sample name (GET with query params)",
+                "description": "All parameters are optional query parameters.\nResults limited to 100 for public API.",
+                "operationId": "get_datasets_by_sample_name_simple",
+                "parameters": [
+                    {
+                        "description": "Search algorithm: \"like\" (fast), \"regex\" (moderate), \"fuzzy\" (slow)",
+                        "name": "search_mode",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Filter by key pattern (e.g., \"krios\", \"pncc\")",
+                        "name": "key_filter",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Exact match (true/false, default: false)",
+                        "name": "exact_match",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Case-sensitive (true/false, default: false)",
+                        "name": "case_sensitive",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Fuzzy mode: min similarity 0.0-1.0 (default: 0.6)",
+                        "name": "similarity_threshold",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Max results, capped at 100 (default: 20)",
+                        "name": "limit",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Pagination offset (default: 0)",
+                        "name": "offset",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/by_sample_name": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Sample%20Name%20Search%20Result"
+                        }
+                    }
+                },
+                "summary": "Search for datasets by sample name with advanced options",
+                "description": "Search modes with performance characteristics:\n\n**LIKE (default, fastest ~2-3s):** SQL pattern matching\n**Regex (moderate ~3-5s):** Full regex support  \n**Fuzzy (optimized ~2-4s):** Typo-tolerant, returns similarity scores\n\nFuzzy mode uses optimized two-phase algorithm for fast performance.\n\n**Example LIKE search:**\n```json\n{\"sample_name\": \"test\", \"search_mode\": \"like\", \"limit\": 20}\n```\n\n**Example Regex search (starts with \"test\"):**\n```json\n{\"sample_name\": \"^test\", \"search_mode\": \"regex\", \"limit\": 20}\n```\n\n**Example Fuzzy search (typo-tolerant):**\n```json\n{\"sample_name\": \"sampel123\", \"search_mode\": \"fuzzy\", \"similarity_threshold\": 0.6}\n```\n\nNote: Results limited to max 100 for public API.",
+                "operationId": "post_datasets_by_sample_name",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/Sample%20Name%20Search%20Input"
+                        }
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/download/{download_uuid}": {
+            "parameters": [
+                {
+                    "name": "download_uuid",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Retrieve a pre-existing Download Cart",
+                        "schema": {
+                            "$ref": "#/definitions/Cart%20Info"
+                        }
+                    }
+                },
+                "operationId": "get_cart_operations",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "datasets"
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Cart%20Basic%20Status"
+                        }
+                    },
+                    "204": {
+                        "description": "Deletes a pre-existing Download Cart",
+                        "schema": {
+                            "$ref": "#/definitions/Cart%20Basic%20Status"
+                        }
+                    }
+                },
+                "operationId": "delete_cart_operations",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/info/{download_uuid}": {
+            "parameters": [
+                {
+                    "name": "download_uuid",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Cart%20Details%20Entry"
+                        }
+                    }
+                },
+                "operationId": "get_get_cart_info",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/limit/{limit}": {
+            "parameters": [
+                {
+                    "name": "limit",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_dataset_limit_api",
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/limit/{limit}/offset/{offset}": {
+            "parameters": [
+                {
+                    "name": "limit",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "offset",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_dataset_limit_api",
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/request/{transaction_id}": {
+            "parameters": [
+                {
+                    "name": "transaction_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "201": {
+                        "description": "Create a new Download Cart",
+                        "schema": {
+                            "$ref": "#/definitions/Cart%20Info"
+                        }
+                    }
+                },
+                "operationId": "get_cart_from_transaction",
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/transaction_info/{transaction_id}": {
+            "parameters": [
+                {
+                    "name": "transaction_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_transaction_info",
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/datasets/{dataset_id}": {
+            "parameters": [
+                {
+                    "name": "dataset_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_dataset_by_id",
+                "tags": [
+                    "datasets"
+                ]
+            }
+        },
+        "/monet/analysis_activity/{study}/{sample_set}/{analysis}": {
+            "parameters": [
+                {
+                    "name": "study",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "sample_set",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "analysis",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get analysis metadata for a sample set",
+                "operationId": "get_analysis_activity",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/ber/geofence": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get samples within a geographical boundary",
+                "operationId": "get_ber_geofence",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/changelog/{version}": {
+            "parameters": [
+                {
+                    "name": "version",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Retrieve changelogs for a version number",
+                "operationId": "get_changelog",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/elastic/metadata": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get metadata from Elasticsearch",
+                "operationId": "get_elastic_metadata",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/elastic/{analysis}": {
+            "parameters": [
+                {
+                    "name": "analysis",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get analysis metadata from Elasticsearch",
+                "operationId": "get_elastic_analysis",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/processed_data/{study}/{sample_set}/{analysis}": {
+            "parameters": [
+                {
+                    "name": "study",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "sample_set",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "analysis",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get processed data for a sample set",
+                "operationId": "get_processed_data",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/sample": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Retrieve paginated list of sample metadata",
+                "operationId": "get_sample_list",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/sample/cores": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get all cores",
+                "operationId": "get_cores",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/study": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get all Study entries",
+                "operationId": "get_all_studies",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/monet/study/{id}": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get a Study by ID (uuid or project id)",
+                "operationId": "get_single_study",
+                "tags": [
+                    "monet"
+                ]
+            }
+        },
+        "/projects/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the full list of projects",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Projects"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_projects_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ]
+            }
+        },
+        "/projects/active": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the full list of projects",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Projects"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_projects_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ]
+            }
+        },
+        "/projects/all": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the full list of projects",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Projects"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_projects_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ]
+            }
+        },
+        "/projects/data/{project_identifier}": {
+            "parameters": [
+                {
+                    "description": "Page of results to return (defaults to 1)",
+                    "name": "page",
+                    "type": "string",
+                    "in": "query"
+                },
+                {
+                    "description": "Number of results per page defaults to 50)",
+                    "name": "items_per_page",
+                    "type": "string",
+                    "in": "query"
+                },
+                {
+                    "name": "project_identifier",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get datasets for a single project entry",
+                        "schema": {
+                            "$ref": "#/definitions/Project%20Datasets%20Model"
+                        }
+                    }
+                },
+                "operationId": "get_project_data_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ]
+            }
+        },
+        "/projects/search/{search_term}": {
+            "parameters": [
+                {
+                    "name": "search_term",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "search for projects",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Projects"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_project_search_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ]
+            }
+        },
+        "/projects/{project_identifier}": {
+            "parameters": [
+                {
+                    "name": "project_identifier",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get a single project entry",
+                        "schema": {
+                            "$ref": "#/definitions/Project_Details"
+                        }
+                    }
+                },
+                "operationId": "get_project_details_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ]
+            }
+        },
+        "/resources/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the full list of resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resources"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_resources_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "resources"
+                ]
+            }
+        },
+        "/resources/active": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the full list of resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resources"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_resources_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "resources"
+                ]
+            }
+        },
+        "/resources/all": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the full list of resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resources"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_resources_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "resources"
+                ]
+            }
+        },
+        "/resources/grouping": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource_Grouping"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_resource_grouping",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "resources"
+                ]
+            }
+        },
+        "/resources/search/{search_term}": {
+            "parameters": [
+                {
+                    "name": "search_term",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Search for a resource",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resources"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_resource_search_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "resources"
+                ]
+            }
+        },
+        "/resources/{resource_id}": {
+            "parameters": [
+                {
+                    "name": "resource_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get a specific resource by id",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resources"
+                            }
+                        }
+                    }
+                },
+                "operationId": "get_user_details_api",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "resources"
+                ]
+            }
+        },
+        "/search/projects": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "404": {
+                        "description": "No Results Found"
+                    },
+                    "400": {
+                        "description": "Validation Error or No Search Terms"
+                    }
+                },
+                "operationId": "get_project_term_search__api",
+                "parameters": [
+                    {
+                        "description": "Project ID value",
+                        "name": "project_id",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "String contained in Project title",
+                        "name": "title",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "String contained in Project abstract",
+                        "name": "abstract",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "'y' to return only active projects",
+                        "name": "is_active",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "String contained in project type",
+                        "name": "proj_type",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Retrieve only projects starting after the specified date",
+                        "name": "started",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Retrieve only projects ending before the specified date",
+                        "name": "ended",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Page of results to return (defaults to 1)",
+                        "name": "page",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Number of Datasets per page (defaults to 50)",
+                        "name": "items_per_page",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "search"
+                ]
+            }
+        }
+    },
+    "info": {
+        "title": "External API",
+        "version": "1.0",
+        "description": "Slimmed down endpoint for external exposure"
+    },
+    "produces": [
+        "application/json"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "tags": [
+        {
+            "name": "projects"
+        },
+        {
+            "name": "resources"
+        },
+        {
+            "name": "datasets"
+        },
+        {
+            "name": "search"
+        },
+        {
+            "name": "monet",
+            "description": "MONet Data Portal operations"
+        }
+    ],
+    "definitions": {
+        "Projects": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Projects_Abbreviated"
+                },
+                {
+                    "properties": {
+                        "title": {
+                            "type": "string"
+                        },
+                        "project_type": {
+                            "type": "string"
+                        },
+                        "active": {
+                            "type": "boolean"
+                        },
+                        "accepted": {
+                            "type": "boolean"
+                        },
+                        "award_doi": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "Projects_Abbreviated": {
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                },
+                "uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Project_Details": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Projects"
+                },
+                {
+                    "properties": {
+                        "abstract": {
+                            "type": "string"
+                        },
+                        "started_date": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "closed_date": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "current_status": {
+                            "type": "string"
+                        },
+                        "project_members": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Project_Member"
+                            }
+                        },
+                        "project_type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "Project_Member": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Base_User"
+                },
+                {
+                    "properties": {
+                        "project_role": {
+                            "type": "string"
+                        },
+                        "orcid": {
+                            "type": "string"
+                        },
+                        "institution": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "Base_User": {
+            "properties": {
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Project Datasets Model": {
+            "properties": {
+                "project": {
+                    "type": "object"
+                },
+                "datasets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Dataset Display Model"
+                    }
+                }
+            },
+            "type": "object"
+        },
+        "Dataset Display Model": {
+            "properties": {
+                "upload_identifier": {
+                    "type": "integer"
+                },
+                "resource": {
+                    "type": "object"
+                },
+                "date_created": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "is_released": {
+                    "type": "boolean"
+                },
+                "total_file_count": {
+                    "type": "integer"
+                },
+                "total_file_size": {
+                    "type": "integer"
+                },
+                "friendly_file_size": {
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Resources": {
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "active": {
+                    "type": "boolean"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "available_hours": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Resource_Grouping": {
+            "properties": {
+                "resource_uuid": {
+                    "type": "string"
+                },
+                "resource_id": {
+                    "type": "string"
+                },
+                "resource_name": {
+                    "type": "string"
+                },
+                "group": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Cart Info": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Cart Basic Status"
+                },
+                {
+                    "properties": {
+                        "display_status": {
+                            "type": "string"
+                        },
+                        "retrieval_url": {
+                            "type": "string"
+                        },
+                        "status_url": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "Cart Basic Status": {
+            "properties": {
+                "download_uuid": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Cart Details Entry": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Cart Info"
+                },
+                {
+                    "properties": {
+                        "cart_name": {
+                            "type": "string"
+                        },
+                        "cart_description": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "file_count": {
+                            "type": "integer"
+                        },
+                        "transaction_id": {
+                            "type": "integer"
+                        },
+                        "resource_uuid": {
+                            "type": "string"
+                        },
+                        "project_uuid": {
+                            "type": "string"
+                        },
+                        "download_attempts_count": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "Sample Name Search Input": {
+            "required": [
+                "sample_name"
+            ],
+            "properties": {
+                "sample_name": {
+                    "type": "string",
+                    "description": "Sample name to search for. Supports wildcards in 'like' mode, regex patterns in 'regex' mode, or fuzzy matching in 'fuzzy' mode.",
+                    "example": "test-sample"
+                },
+                "key_filter": {
+                    "type": "string",
+                    "description": "Filter to specific key pattern (e.g., 'krios', 'pncc', 'short_sample_name'). If omitted, searches all keys containing 'sample'.",
+                    "example": "short_sample_name"
+                },
+                "exact_match": {
+                    "type": "boolean",
+                    "description": "If true, requires exact match of sample_name. If false, allows partial matches. Overrides search_mode when true.",
+                    "default": false,
+                    "example": false
+                },
+                "search_mode": {
+                    "type": "string",
+                    "description": "Search algorithm to use:\n            - 'like' (default, fastest ~2-3s): SQL LIKE pattern matching. Use % as wildcard.\n            - 'regex' (moderate ~3-5s): PostgreSQL regex matching. Supports ^, $, .*, [0-9], etc.\n            - 'fuzzy' (optimized ~2-4s): Similarity-based matching, tolerates typos. Returns similarity_score for each result. Uses two-phase optimization.",
+                    "default": "like",
+                    "example": "like",
+                    "enum": [
+                        "like",
+                        "regex",
+                        "fuzzy"
+                    ]
+                },
+                "similarity_threshold": {
+                    "type": "number",
+                    "description": "For fuzzy mode only: Minimum similarity score (0.0-1.0). Higher values = stricter matching. Recommended: 0.3 (loose) to 0.7 (strict).",
+                    "default": 0.6,
+                    "example": 0.6
+                },
+                "case_sensitive": {
+                    "type": "boolean",
+                    "description": "If true, search is case-sensitive. If false (default), search is case-insensitive. Applies to all search modes.",
+                    "default": false,
+                    "example": false
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (max: 100). Default: 20.",
+                    "default": 20,
+                    "example": 20
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of results to skip for pagination. Default: 0.",
+                    "default": 0,
+                    "example": 0
+                }
+            },
+            "type": "object"
+        },
+        "Sample Name Search Result": {
+            "properties": {
+                "total_count": {
+                    "type": "integer",
+                    "description": "Total number of matching transactions"
+                },
+                "transactions": {
+                    "type": "array",
+                    "description": "List of matching transactions",
+                    "items": {
+                        "$ref": "#/definitions/Sample Transaction"
+                    }
+                },
+                "search_mode": {
+                    "type": "string",
+                    "description": "The search mode used: 'like', 'regex', or 'fuzzy'"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum results returned"
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of results skipped"
+                }
+            },
+            "type": "object"
+        },
+        "Sample Transaction": {
+            "properties": {
+                "transaction_id": {
+                    "type": "integer",
+                    "description": "Pacifica transaction/upload ID"
+                },
+                "sample_key": {
+                    "type": "string",
+                    "description": "The metadata key (e.g., 'krios.short_sample_name')"
+                },
+                "sample_value": {
+                    "type": "string",
+                    "description": "The sample name value"
+                },
+                "submitter_id": {
+                    "type": "integer",
+                    "description": "User ID who submitted the upload"
+                },
+                "instrument_id": {
+                    "type": "integer",
+                    "description": "Instrument/resource ID"
+                },
+                "project_id": {
+                    "type": "string",
+                    "description": "Project identifier"
+                },
+                "created": {
+                    "type": "string",
+                    "description": "Transaction creation timestamp (ISO 8601)"
+                },
+                "similarity_score": {
+                    "type": "number",
+                    "description": "Similarity score (0.0-1.0). Only present when search_mode='fuzzy'. Higher = better match."
+                }
+            },
+            "type": "object"
+        }
+    },
+    "responses": {
+        "ParseError": {
+            "description": "When a mask can't be parsed"
+        },
+        "MaskError": {
+            "description": "When any error occurs on mask"
+        }
+    }
+}

--- a/src/lambda_ber_schema/cli.py
+++ b/src/lambda_ber_schema/cli.py
@@ -360,6 +360,34 @@ def etl_emsl(
             help="Maximum transactions to consider in sample search",
         ),
     ] = 20,
+    extract_epu: Annotated[
+        bool,
+        typer.Option(
+            "--extract-epu/--no-extract-epu",
+            help=(
+                "Extract EPU session metadata from the transaction tar archive. "
+                "Requires EMSL_JWT env var (JWT bearer token). "
+                "When set, acquisition parameters (magnification, dose, pixel size, etc.) "
+                "are added to the ExperimentRun in the output."
+            ),
+        ),
+    ] = False,
+    token: Annotated[
+        str | None,
+        typer.Option(
+            "--token",
+            help="EMSL JWT bearer token (overrides EMSL_JWT env var)",
+            envvar="EMSL_JWT",
+            show_default=False,
+        ),
+    ] = None,
+    epu_timeout: Annotated[
+        float,
+        typer.Option(
+            "--epu-timeout",
+            help="Seconds to wait for the EMSL download cart to become ready before giving up.",
+        ),
+    ] = 1800.0,
 ) -> None:
     """
     Load data from the EMSL public API using sample-search transactions.
@@ -370,13 +398,23 @@ def etl_emsl(
 
         lambda-ber-schema etl emsl --sample apo --transaction-id 3736677
 
+        lambda-ber-schema etl emsl --sample apo --extract-epu --format json
+
         lambda-ber-schema etl emsl --sample apo --format json --cache
     """
     response_cache = ResponseCache(
         cache_dir=cache_dir or Path(".cache"),
         enabled=cache,
     )
-    loader = EMSLLoader(cache=response_cache)
+    jwt = token if extract_epu else None
+    loader = EMSLLoader(cache=response_cache, jwt_token=jwt, epu_timeout=epu_timeout)
+
+    if extract_epu and not jwt:
+        typer.echo(
+            "Warning: --extract-epu requested but no JWT token found. "
+            "Set EMSL_JWT or use --token. EPU metadata will be skipped.",
+            err=True,
+        )
 
     typer.echo(f"Loading EMSL sample query: {sample}", err=True)
     result = _run_with_error_handling(

--- a/src/lambda_ber_schema/loaders/emsl.py
+++ b/src/lambda_ber_schema/loaders/emsl.py
@@ -6,10 +6,15 @@ API Documentation:
   - https://api.emsl.pnnl.gov/external/swagger.json
 """
 
+import io
 import json
+import os
 import re
+import tarfile
+import time
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Generator
 
 import requests
 
@@ -56,15 +61,31 @@ class EMSLLoader(BaseLoader):
     source_name = "emsl"
     base_url = "https://api.emsl.pnnl.gov/external"
 
+    # Metadata file patterns to extract from EPU tar archives.
+    # Ordered by preference: session-level XML first, then notes.
+    _EPU_METADATA_PATTERNS = (
+        re.compile(r"EpuSession\.dm$", re.IGNORECASE),
+        re.compile(r".*[Ss]ession.*\.dm$"),
+        re.compile(r".*[Ss]ession.*\.xml$"),
+        re.compile(r"notes?\.txt$", re.IGNORECASE),
+        re.compile(r".*[Ss]ession.*[Ss]ummary.*\.yaml$", re.IGNORECASE),
+    )
+
     def __init__(
         self,
         cache: ResponseCache | None = None,
         default_key_filter: str | None = "pncc",
         max_files: int = 200,
+        jwt_token: str | None = None,
+        epu_timeout: float = 1800.0,
     ):
         self.cache = cache or ResponseCache(enabled=False)
         self.default_key_filter = default_key_filter
         self.max_files = max_files
+        # JWT bearer token for authenticated endpoints (download cart, file download).
+        # Falls back to the EMSL_JWT environment variable when not provided explicitly.
+        self._jwt_token: str | None = jwt_token or os.environ.get("EMSL_JWT")
+        self._epu_timeout: float = epu_timeout
 
     def load(self, identifier: str) -> LoaderResult:
         """
@@ -238,6 +259,284 @@ class EMSLLoader(BaseLoader):
 
         return entries
 
+    # ── EPU XML Parsing ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _text(root: ET.Element, *xpaths: str) -> str | None:
+        """Return stripped text of the first matching XPath, or None."""
+        for xpath in xpaths:
+            el = root.find(xpath)
+            if el is not None and el.text:
+                return el.text.strip()
+        return None
+
+    @staticmethod
+    def _float(root: ET.Element, *xpaths: str) -> float | None:
+        """Return float value of the first matching XPath, or None."""
+        for xpath in xpaths:
+            el = root.find(xpath)
+            if el is not None and el.text:
+                try:
+                    return float(el.text.strip())
+                except ValueError:
+                    pass
+        return None
+
+    def _parse_epu_session_xml(self, content: bytes) -> dict[str, Any]:
+        """
+        Parse an EPU session file (EpuSession.dm or Session*.xml) and return
+        a dict of acquisition parameters keyed by ExperimentRun field names.
+
+        EPU XML schema varies across versions; this parser tries multiple known
+        XPaths per field and falls back gracefully. All returned values are raw
+        Python types (float, str, int) — QuantityValue wrapping is done by
+        the caller.
+
+        Returns an empty dict if the file cannot be parsed as valid XML.
+        """
+        try:
+            root = ET.fromstring(content)
+        except ET.ParseError:
+            return {}
+
+        # Strip all namespace prefixes for XPath simplicity.
+        for el in root.iter():
+            if "}" in el.tag:
+                el.tag = el.tag.split("}", 1)[1]
+
+        result: dict[str, Any] = {}
+
+        # Software version — several possible locations across EPU versions.
+        version = self._text(
+            root,
+            ".//Version",
+            ".//SoftwareVersion",
+            ".//ApplicationVersion",
+            ".//version",
+        )
+        if version:
+            result["acquisition_software_version"] = version
+
+        # Magnification
+        mag = self._float(
+            root,
+            ".//Magnification",
+            ".//NominalMagnification",
+            ".//magnification",
+            ".//Optics/Magnification",
+        )
+        if mag:
+            result["magnification"] = {"numeric_value": mag, "unit": "x"}
+
+        # Calibrated pixel size — EPU stores in meters, convert to Å.
+        for xpath in (".//PixelSize", ".//pixelSize", ".//CalibratedPixelSize"):
+            el = root.find(xpath)
+            if el is not None and el.text:
+                try:
+                    px_m = float(el.text.strip())
+                    # Values > 1e-6 are already in µm or Å (old EPU); < 1e-6 are meters.
+                    if px_m < 1e-6:
+                        px_angstrom = px_m * 1e10
+                    elif px_m < 1e-3:
+                        px_angstrom = px_m * 1e4  # µm → Å
+                    else:
+                        px_angstrom = px_m  # already Å-range
+                    result["calibrated_pixel_size"] = {
+                        "numeric_value": round(px_angstrom, 4),
+                        "unit": "Å/pixel",
+                    }
+                    break
+                except ValueError:
+                    pass
+
+        # Camera binning
+        binning = self._float(
+            root,
+            ".//Binning",
+            ".//CameraBinning",
+            ".//binning",
+            ".//CameraPreset/Binning",
+        )
+        if binning is not None:
+            result["camera_binning"] = {"numeric_value": binning, "unit": ""}
+
+        # Exposure time per frame — may be in seconds, convert to ms.
+        for xpath in (
+            ".//ExposureTime",
+            ".//FrameExposureTime",
+            ".//exposureTime",
+            ".//CameraPreset/ExposureTime",
+        ):
+            el = root.find(xpath)
+            if el is not None and el.text:
+                try:
+                    t = float(el.text.strip())
+                    # Values < 10 are likely seconds; > 10 are likely ms.
+                    t_ms = t * 1000 if t < 10 else t
+                    result["exposure_time_per_frame"] = {
+                        "numeric_value": round(t_ms, 3),
+                        "unit": "ms",
+                    }
+                    break
+                except ValueError:
+                    pass
+
+        # Frames per movie
+        frames = self._float(
+            root,
+            ".//NumberOffractions",
+            ".//FramesPerExposure",
+            ".//FrameMultiplier",
+            ".//framesPerExposure",
+            ".//Acquisition/FramesPerShot",
+            ".//CameraPreset/NumberOffractions",
+        )
+        if frames is not None:
+            result["frames_per_movie"] = {"numeric_value": int(frames), "unit": ""}
+
+        # Total dose (e-/Å²)
+        dose = self._float(
+            root,
+            ".//TotalExposureDose",
+            ".//TotalDose",
+            ".//DosePerFrame",
+            ".//totalDose",
+        )
+        if dose:
+            # If dose looks like per-frame dose (< 5), multiply by frames to get total.
+            if dose < 5 and "frames_per_movie" in result:
+                dose_total = dose * result["frames_per_movie"]["numeric_value"]
+                result["total_dose"] = {"numeric_value": round(dose_total, 2), "unit": "e-/Å²"}
+                result["dose_per_frame"] = {"numeric_value": round(dose, 4), "unit": "e-/Å²/frame"}
+            else:
+                result["total_dose"] = {"numeric_value": round(dose, 2), "unit": "e-/Å²"}
+
+        # Dose rate
+        dose_rate = self._float(root, ".//DoseRate", ".//doseRate")
+        if dose_rate:
+            result["dose_rate"] = {"numeric_value": dose_rate, "unit": "e-/pixel/s"}
+
+        # Defocus target / range
+        defocus_target = self._float(
+            root,
+            ".//TargetDefocus",
+            ".//DefocusTarget",
+            ".//defocusTarget",
+            ".//Presets/AutoFocus/Defocus",
+        )
+        if defocus_target is not None:
+            # EPU stores in meters; convert to µm.
+            if abs(defocus_target) < 0.1:
+                defocus_target = defocus_target * 1e6
+            result["defocus_target"] = {
+                "numeric_value": round(defocus_target, 3),
+                "unit": "µm",
+            }
+
+        defocus_min = self._float(root, ".//MinDefocus", ".//DefocusMin", ".//minDefocus")
+        defocus_max = self._float(root, ".//MaxDefocus", ".//DefocusMax", ".//maxDefocus")
+        if defocus_min is not None:
+            if abs(defocus_min) < 0.1:
+                defocus_min = defocus_min * 1e6
+            result["defocus_range_min"] = {"numeric_value": round(defocus_min, 3), "unit": "µm"}
+        if defocus_max is not None:
+            if abs(defocus_max) < 0.1:
+                defocus_max = defocus_max * 1e6
+            result["defocus_range_max"] = {"numeric_value": round(defocus_max, 3), "unit": "µm"}
+
+        # Shots per hole
+        shots = self._float(
+            root,
+            ".//ShotsPerHole",
+            ".//shotsPerHole",
+            ".//NumberOfShotsPerHole",
+            ".//Acquisition/ShotsPerHole",
+        )
+        if shots is not None:
+            result["shots_per_hole"] = {"numeric_value": int(shots), "unit": ""}
+
+        # Holes per group
+        holes = self._float(
+            root,
+            ".//HolesPerGroup",
+            ".//holesPerGroup",
+            ".//NumberOfHoles",
+        )
+        if holes is not None:
+            result["holes_per_group"] = {"numeric_value": int(holes), "unit": ""}
+
+        # Stage tilt
+        tilt = self._float(root, ".//StageTilt", ".//stageTilt", ".//TiltAngle")
+        if tilt is not None:
+            result["stage_tilt"] = {"numeric_value": round(tilt, 2), "unit": "degrees"}
+
+        return result
+
+    # ── Public Enhanced Load ──────────────────────────────────────────────────
+
+    def extract_session_metadata(self, transaction_id: int | str) -> dict[str, Any] | None:
+        """
+        Fetch and parse EPU session metadata from a transaction's tar archive.
+
+        Requires a JWT token (EMSL_JWT env var or jwt_token= constructor arg).
+        Returns a dict of acquisition parameter fields keyed by ExperimentRun
+        field names, or None when the token is absent or no metadata file is found.
+
+        Emits a warning to stderr when JWT is not configured so callers can
+        treat the absence gracefully.
+
+        Example::
+
+            loader = EMSLLoader()  # reads EMSL_JWT from environment
+            params = loader.extract_session_metadata(3736677)
+            if params:
+                print(params["magnification"])
+        """
+        if not self._jwt_token:
+            import sys
+            print(
+                "Warning: EMSL_JWT not set — skipping EPU session metadata extraction. "
+                "Set the EMSL_JWT environment variable to enable.",
+                file=sys.stderr,
+            )
+            return None
+
+        tx_id = str(transaction_id)
+        try:
+            retrieval_url = self._get_retrieval_url(tx_id)
+        except (requests.HTTPError, RuntimeError, TimeoutError) as exc:
+            import sys
+            print(f"Warning: could not create download cart for tx {tx_id}: {exc}", file=sys.stderr)
+            return None
+
+        found: dict[str, Any] = {}
+        notes_content: str | None = None
+
+        for name, content in self._stream_tar_members(retrieval_url):
+            lower = name.lower()
+            if lower.endswith((".dm", ".xml")):
+                parsed = self._parse_epu_session_xml(content)
+                if parsed:
+                    found.update(parsed)
+                    found["_source_file"] = name
+                    break  # session XML found, stop streaming
+            elif lower.endswith((".yaml", ".yml")):
+                # Try YAML session summary — parse as key/value dict.
+                try:
+                    import yaml  # type: ignore[import]
+                    data = yaml.safe_load(content.decode("utf-8", errors="replace"))
+                    if isinstance(data, dict):
+                        found.update({"_yaml_source": name, "_yaml_raw": data})
+                except Exception:
+                    pass
+            elif "notes" in lower:
+                notes_content = content.decode("utf-8", errors="replace").strip()
+
+        if notes_content:
+            found["_notes"] = notes_content
+
+        return found if found else None
+
     def _sort_transactions(self, transactions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Sort transactions by most recent creation time, then by transaction ID."""
 
@@ -271,6 +570,200 @@ class EMSLLoader(BaseLoader):
             ),
             reverse=True,
         )
+
+    # ── Authentication ────────────────────────────────────────────────────────
+
+    def _get_auth_headers(self) -> dict[str, str]:
+        """Return Authorization header dict if a JWT token is available."""
+        if self._jwt_token:
+            return {"Authorization": f"Bearer {self._jwt_token}"}
+        return {}
+
+    # ── Download Cart ─────────────────────────────────────────────────────────
+
+    def _create_download_cart(self, transaction_id: int | str) -> dict[str, Any]:
+        """
+        Create a download cart for a transaction.
+
+        Calls GET /datasets/request/{transaction_id} with JWT auth and returns
+        the Cart Info response containing download_uuid and retrieval_url.
+
+        Raises:
+            RuntimeError: If no JWT token is configured.
+            requests.HTTPError: On non-2xx response.
+        """
+        if not self._jwt_token:
+            raise RuntimeError(
+                "Downloading data from EMSL requires a JWT bearer token. "
+                "Set the EMSL_JWT environment variable or pass jwt_token= to EMSLLoader."
+            )
+        tx_id = str(transaction_id)
+        response = requests.get(
+            f"{self.base_url}/datasets/request/{tx_id}",
+            headers=self._get_auth_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        return self._parse_json_response(response, "download cart creation")
+
+    def _poll_download_cart(
+        self,
+        download_uuid: str,
+        poll_interval: float = 5.0,
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        """
+        Poll GET /datasets/download/{download_uuid} until the cart is ready.
+
+        Returns the final Cart Info dict (with retrieval_url populated).
+
+        Raises:
+            TimeoutError: If cart preparation exceeds timeout seconds.
+            requests.HTTPError: On non-2xx response.
+        """
+        import sys
+        deadline = time.monotonic() + timeout
+        while True:
+            response = requests.get(
+                f"{self.base_url}/datasets/download/{download_uuid}",
+                headers=self._get_auth_headers(),
+                timeout=30,
+            )
+            response.raise_for_status()
+            cart = self._parse_json_response(response, "download cart poll")
+            status = str(cart.get("status") or "").lower()
+            display = cart.get("display_status") or status
+            print(f"  cart {download_uuid}: {display} (status={status!r})", file=sys.stderr)
+            # Consider the cart ready when:
+            #   - status matches a known "done" keyword, OR
+            #   - success=True and retrieval_url is present (covers "File Retrieval" etc.)
+            retrieval_url = cart.get("retrieval_url")
+            if status in ("ready", "complete", "completed"):
+                return cart
+            if cart.get("success") is True and retrieval_url:
+                return cart
+            if status in ("error", "failed", "cancelled"):
+                raise RuntimeError(
+                    f"EMSL download cart {download_uuid} entered error state: {status}. "
+                    f"message={cart.get('message')}"
+                )
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"EMSL download cart {download_uuid} not ready after {timeout}s "
+                    f"(last status: {status!r})"
+                )
+            time.sleep(poll_interval)
+
+    def _resolve_url(self, url: str) -> str:
+        """Resolve a potentially relative API URL to an absolute HTTPS URL."""
+        if url.startswith("http://") or url.startswith("https://"):
+            return url
+        # Relative paths like /external/datasets/download/... — prepend the host.
+        host = "https://api.emsl.pnnl.gov"
+        return host + url if url.startswith("/") else f"{host}/{url}"
+
+    def _extract_cart_uuid(self, cart: dict[str, Any]) -> str | None:
+        """Extract the cart UUID from a cart response, handling field name variants."""
+        return (
+            cart.get("download_uuid")
+            or cart.get("cart_uuid")
+            or cart.get("uuid")
+        )
+
+    def _get_retrieval_url(self, transaction_id: int | str) -> str:
+        """
+        Create a download cart and wait for it to be ready, returning the retrieval URL.
+        """
+        cart = self._create_download_cart(transaction_id)
+        cart_uuid = self._extract_cart_uuid(cart)
+        retrieval_url: str | None = cart.get("retrieval_url")
+
+        # If the cart already has a retrieval_url and appears ready, return immediately.
+        status = str(cart.get("status") or "").lower()
+        if retrieval_url and status in ("ready", "complete", "completed"):
+            return self._resolve_url(retrieval_url)
+
+        # Otherwise poll until ready.
+        if not cart_uuid:
+            raise RuntimeError(
+                f"EMSL download cart response missing download_uuid/cart_uuid: {cart}"
+            )
+        ready_cart = self._poll_download_cart(cart_uuid, timeout=self._epu_timeout)
+        retrieval_url = ready_cart.get("retrieval_url")
+        if not retrieval_url:
+            raise RuntimeError(
+                f"EMSL download cart {cart_uuid} is ready but has no retrieval_url"
+            )
+        return self._resolve_url(retrieval_url)
+
+    # ── Streaming Tar Extraction ──────────────────────────────────────────────
+
+    def _stream_tar_members(
+        self,
+        url: str,
+        chunk_size: int = 1024 * 1024,
+    ) -> Generator[tuple[str, bytes], None, None]:
+        """
+        Stream a remote .tar file and yield (member_name, content) for each
+        member whose name matches one of _EPU_METADATA_PATTERNS.
+
+        Uses sequential tarfile streaming (mode='r|') so only the first
+        matching members need to be downloaded — the stream is closed early
+        once all pattern groups are satisfied.
+
+        Args:
+            url: HTTPS URL to stream the tar file from.
+            chunk_size: Read chunk size in bytes.
+
+        Yields:
+            Tuples of (tar_member_name, raw_bytes).
+        """
+        with requests.get(
+            url,
+            headers=self._get_auth_headers(),
+            stream=True,
+            timeout=60,
+        ) as response:
+            response.raise_for_status()
+
+            class _StreamingFileObj(io.RawIOBase):
+                """Wrap a requests streaming response as a file-like object."""
+                def __init__(self, resp: requests.Response) -> None:
+                    self._iter = resp.iter_content(chunk_size=chunk_size)
+                    self._buf = b""
+
+                def readinto(self, b: bytearray) -> int:
+                    while len(self._buf) < len(b):
+                        try:
+                            self._buf += next(self._iter)
+                        except StopIteration:
+                            break
+                    n = min(len(b), len(self._buf))
+                    b[:n] = self._buf[:n]
+                    self._buf = self._buf[n:]
+                    return n
+
+                def readable(self) -> bool:
+                    return True
+
+            fileobj = io.BufferedReader(_StreamingFileObj(response))
+            satisfied: set[int] = set()
+
+            with tarfile.open(fileobj=fileobj, mode="r|*") as tf:
+                for member in tf:
+                    name = member.name
+                    for idx, pattern in enumerate(self._EPU_METADATA_PATTERNS):
+                        if idx in satisfied:
+                            continue
+                        if pattern.search(name):
+                            fobj = tf.extractfile(member)
+                            if fobj is not None:
+                                yield name, fobj.read()
+                                satisfied.add(idx)
+                            break
+                    # Stop streaming once we have found one match per pattern group.
+                    if len(satisfied) >= len(self._EPU_METADATA_PATTERNS):
+                        break
 
     def _parse_json_response(
         self,
@@ -484,6 +977,13 @@ class EMSLLoader(BaseLoader):
 
         technique = self._infer_technique(
             sample_key, sample_value, resource, files)
+
+        # Optional: enrich with EPU session metadata from tar archive (requires JWT).
+        epu = self._build_epu_quantity_values(
+            self.extract_session_metadata(tx_id)
+            if self._jwt_token else None
+        )
+
         experiment = ExperimentRun(
             id=experiment_id,
             experiment_code=f"EMSL-TX-{tx_id}",
@@ -494,6 +994,20 @@ class EMSLLoader(BaseLoader):
             raw_data_location=(files[0].get("path") if files else None),
             processing_status=ProcessingStatusEnum.collected,
             acquisition_software=self._infer_acquisition_software(files),
+            acquisition_software_version=epu.get("acquisition_software_version"),
+            magnification=epu.get("magnification"),
+            calibrated_pixel_size=epu.get("calibrated_pixel_size"),
+            camera_binning=epu.get("camera_binning"),
+            exposure_time_per_frame=epu.get("exposure_time_per_frame"),
+            frames_per_movie=epu.get("frames_per_movie"),
+            total_dose=epu.get("total_dose"),
+            dose_rate=epu.get("dose_rate"),
+            defocus_target=epu.get("defocus_target"),
+            defocus_range_min=epu.get("defocus_range_min"),
+            defocus_range_max=epu.get("defocus_range_max"),
+            shots_per_hole=epu.get("shots_per_hole"),
+            holes_per_group=epu.get("holes_per_group"),
+            stage_tilt=epu.get("stage_tilt"),
         )
 
         instruments: list[Instrument] = []
@@ -744,6 +1258,36 @@ class EMSLLoader(BaseLoader):
         ]
         kept = [part for part in parts if part]
         return " | ".join(kept) if kept else None
+
+    def _build_epu_quantity_values(
+        self,
+        epu: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """
+        Convert raw EPU metadata dict (from _parse_epu_session_xml) into a dict
+        of QuantityValue objects and plain strings suitable for ExperimentRun fields.
+
+        Fields with raw dict form {"numeric_value": ..., "unit": ...} are wrapped
+        in QuantityValue. String fields (e.g., acquisition_software_version) are
+        passed through as-is. Unknown/private keys (prefixed with _) are dropped.
+        """
+        if not epu:
+            return {}
+        result: dict[str, Any] = {}
+        for key, val in epu.items():
+            if key.startswith("_"):
+                continue
+            if isinstance(val, dict) and "numeric_value" in val:
+                try:
+                    result[key] = QuantityValue(
+                        numeric_value=val["numeric_value"],
+                        unit=val.get("unit") or "",
+                    )
+                except Exception:
+                    pass
+            elif isinstance(val, str):
+                result[key] = val
+        return result
 
     def _normalize_doi(self, value: Any) -> str | None:
         """Normalize award DOI values into a DOI URL."""


### PR DESCRIPTION
This pull request introduces detailed documentation for the EMSL Science Central ETL integration and enhances the CLI to support EPU session metadata extraction. The main focus is on providing comprehensive developer documentation and adding new CLI options to facilitate acquisition metadata extraction via authenticated API calls.

Key additions and improvements:

**Documentation and Developer Guidance:**
* Added a new `README.md` in the `emsl-dev/` directory, thoroughly documenting the EMSL Science Central API endpoints, field mappings, authentication flow, metadata sources, and a phased implementation roadmap for the ETL integration. This includes tables of endpoints, schema mapping findings, and actionable next steps for development.

**CLI Enhancements for EPU Metadata Extraction:**
* Added new CLI options to `etl emsl` in `cli.py`:
  - `--extract-epu/--no-extract-epu` flag to enable extraction of EPU session metadata from transaction archives (requires JWT authentication).
  - `--token` option (or `EMSL_JWT` environment variable) for supplying the JWT bearer token.
  - `--epu-timeout` option to control how long to wait for tape-staged downloads.
* Updated loader initialization to pass new authentication and timeout parameters, and emit a warning if `--extract-epu` is requested without a JWT token.

These changes provide both the documentation foundation and the CLI controls needed for robust, authenticated metadata extraction from EMSL Science Central.