### PR TITLE
Exclude ShEx from gen-project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,9 @@
 # Note: markdown docs are generated via gen-doc to docs/elements/ (in Makefile gendoc target)
 excludes:
   - markdown
+  # ShEx generation currently fails under Python 3.14 due to a pyjsg/ShExJSG
+  # compatibility issue during gen-project initialization.
+  - shex
 
 # Alternatively only specify the generators to run
 # (comment out the above "excludes" section)


### PR DESCRIPTION
## Summary
- exclude ShEx generation from `gen-project` to avoid the Python 3.14 pyjsg/ShExJSG initialization failure
- keep the existing ShEx generator args in config so the generator can be re-enabled once upstream compatibility is fixed

Closes #89.

## Validation
- `uv run gen-project --config-file config.yaml src/lambda_ber_schema/schema/lambda_ber_schema.yaml -d /tmp/lambda-ber-gen-project-89`