### PR TITLE
[codex] Add IHMCIF alignment mappings

### DIFF
--- a/assets/sssom/lambda_ber_schema.sssom.tsv
+++ b/assets/sssom/lambda_ber_schema.sssom.tsv
@@ -2,7 +2,7 @@
 #mapping_set_id: http://w3id.org/lambda/
 #mapping_tool: https://w3id.org/linkml/
 #creator_id: linkml_user
-#mapping_date: 2026-04-24
+#mapping_date: 2026-05-19
 #curie_map: 
 # lambda: http://w3id.org/lambda/
 # lambdaber: http://w3id.org/lambda/
@@ -20,6 +20,7 @@
 # nsls2: https://github.com/NSLS2/BER-LAMBDA/
 # imgCIF: https://github.com/dials/cbflib/blob/main/doc/cif_img_1.8.6.dic#
 # mmCIF: http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/
+# IHMCIF: https://mmcif.wwpdb.org/dictionaries/mmcif_ihm_ext.dic/Items/
 # ROR: https://ror.org/
 # wikidata: http://www.wikidata.org/entity/
 # CHMO: http://purl.obolibrary.org/obo/CHMO_
@@ -145,6 +146,14 @@ lambda:sweep_start	dataCollectionStrategy__sweep_start	skos:exactMatch		mmCIF:_d
 lambda:temperature_k	dataCollectionStrategy__temperature_k	skos:exactMatch		mmCIF:_diffrn.ambient_temp		skos:exactMatch	http://w3id.org/lambda/									
 lambda:total_rotation_deg	dataCollectionStrategy__total_rotation_deg	skos:exactMatch		mmCIF:_diffrn_scan_axis.angle_range		skos:exactMatch	http://w3id.org/lambda/									
 lambda:wavelength_a	dataCollectionStrategy__wavelength_a	skos:exactMatch		mmCIF:_diffrn_radiation_wavelength.wavelength		skos:exactMatch	http://w3id.org/lambda/									
+lambda:data_type	dataFile__data_type	skos:closeMatch		IHMCIF:_ihm_dataset_list.data_type		skos:closeMatch	http://w3id.org/lambda/									
+lambda:file_format	dataFile__file_format	skos:closeMatch		IHMCIF:_ihm_external_files.file_format		skos:closeMatch	http://w3id.org/lambda/									
+lambda:file_path	dataFile__file_path	skos:closeMatch		IHMCIF:_ihm_external_files.file_path		skos:closeMatch	http://w3id.org/lambda/									
+lambda:file_role	dataFile__file_role	skos:relatedMatch		IHMCIF:_ihm_external_files.content_type		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:file_size_bytes	dataFile__file_size_bytes	skos:closeMatch		IHMCIF:_ihm_external_files.file_size_bytes		skos:closeMatch	http://w3id.org/lambda/									
+lambda:related_entity	dataFile__related_entity	skos:relatedMatch		IHMCIF:_ihm_dataset_list.id		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:storage_uri	dataFile__storage_uri	skos:relatedMatch		IHMCIF:_ihm_external_reference_info.associated_url		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:storage_uri	dataFile__storage_uri	skos:relatedMatch		IHMCIF:_ihm_external_files.file_path		skos:relatedMatch	http://w3id.org/lambda/									
 lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		nsls2:Beam_xy_x		skos:exactMatch	http://w3id.org/lambda/									
 lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		imgCIF:_diffrn_detector.beam_centre_x		skos:exactMatch	http://w3id.org/lambda/									
 lambda:beam_center_x	experimentRun__beam_center_x	skos:exactMatch		mmCIF:_diffrn_detector.beam_center_x		skos:exactMatch	http://w3id.org/lambda/									
@@ -192,6 +201,7 @@ lambda:start_time	experimentRun__start_time	skos:exactMatch		ispyb:DataCollectio
 lambda:sweep_start	experimentRun__sweep_start	skos:exactMatch		imgCIF:_diffrn_scan_axis.angle_start		skos:exactMatch	http://w3id.org/lambda/									
 lambda:sweep_start	experimentRun__sweep_start	skos:exactMatch		ispyb:DataCollection.axisStart		skos:exactMatch	http://w3id.org/lambda/									
 lambda:synchrotron_mode	experimentRun__synchrotron_mode	skos:exactMatch		ispyb:DataCollection.synchrotronMode		skos:exactMatch	http://w3id.org/lambda/									
+lambda:technique	experimentRun__technique	skos:relatedMatch		IHMCIF:_ihm_dataset_list.data_type		skos:relatedMatch	http://w3id.org/lambda/									
 lambda:total_dose	experimentRun__total_dose	skos:exactMatch		mmCIF:_em_image_recording.avg_electron_dose_per_image		skos:exactMatch	http://w3id.org/lambda/									
 lambda:total_rotation	experimentRun__total_rotation	skos:exactMatch		nsls2:Total_rotation_deg		skos:exactMatch	http://w3id.org/lambda/									
 lambda:total_rotation	experimentRun__total_rotation	skos:exactMatch		imgCIF:_diffrn_scan_axis.angle_range		skos:exactMatch	http://w3id.org/lambda/									
@@ -213,6 +223,7 @@ lambda:r_pim	qualityMetrics__r_pim	skos:exactMatch		mmCIF:_reflns.pdbx_Rpim_I_al
 lambda:r_work	qualityMetrics__r_work	skos:exactMatch		mmCIF:_refine.ls_R_factor_R_work		skos:exactMatch	http://w3id.org/lambda/									
 lambda:ramachandran_favored_percent	qualityMetrics__ramachandran_favored_percent	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_favored		skos:exactMatch	http://w3id.org/lambda/									
 lambda:ramachandran_outliers_percent	qualityMetrics__ramachandran_outliers_percent	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_outliers		skos:exactMatch	http://w3id.org/lambda/									
+lambda:rg	qualityMetrics__rg	skos:closeMatch		IHMCIF:_ihm_sas_restraint.radius_of_gyration		skos:closeMatch	http://w3id.org/lambda/									
 lambda:space_group	qualityMetrics__space_group	skos:exactMatch		mmCIF:_symmetry.space_group_name_H-M		skos:exactMatch	http://w3id.org/lambda/									
 lambda:unit_cell_a	qualityMetrics__unit_cell_a	skos:exactMatch		mmCIF:_cell.length_a		skos:exactMatch	http://w3id.org/lambda/									
 lambda:unit_cell_alpha	qualityMetrics__unit_cell_alpha	skos:exactMatch		mmCIF:_cell.angle_alpha		skos:exactMatch	http://w3id.org/lambda/									
@@ -236,6 +247,9 @@ lambda:completeness_percent	workflowRun__completeness_percent	skos:exactMatch		m
 lambda:completeness_percent	workflowRun__completeness_percent	skos:exactMatch		ispyb:AutoProcScalingStatistics.completeness		skos:exactMatch	http://w3id.org/lambda/									
 lambda:n_total_observations	workflowRun__n_total_observations	skos:exactMatch		mmCIF:_reflns.number_all		skos:exactMatch	http://w3id.org/lambda/									
 lambda:n_total_unique	workflowRun__n_total_unique	skos:exactMatch		mmCIF:_reflns.number_obs		skos:exactMatch	http://w3id.org/lambda/									
+lambda:parameters_file_path	workflowRun__parameters_file_path	skos:relatedMatch		IHMCIF:_ihm_modeling_protocol_details.script_file_id		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:parameters_file_path	workflowRun__parameters_file_path	skos:relatedMatch		IHMCIF:_ihm_external_files.file_path		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:processing_parameters	workflowRun__processing_parameters	skos:relatedMatch		IHMCIF:_ihm_modeling_protocol_details.description		skos:relatedMatch	http://w3id.org/lambda/									
 lambda:ramachandran_favored	workflowRun__ramachandran_favored	skos:exactMatch		nsls2:Ramachandran_Favored		skos:exactMatch	http://w3id.org/lambda/									
 lambda:ramachandran_favored	workflowRun__ramachandran_favored	skos:exactMatch		mmCIF:_pdbx_struct_quality.ramachandran_favored		skos:exactMatch	http://w3id.org/lambda/									
 lambda:ramachandran_outliers	workflowRun__ramachandran_outliers	skos:exactMatch		nsls2:Ramachandran_Outliers		skos:exactMatch	http://w3id.org/lambda/									
@@ -252,6 +266,7 @@ lambda:rmsd_angles	workflowRun__rmsd_angles	skos:exactMatch		mmCIF:_refine.pdbx_
 lambda:rmsd_bonds	workflowRun__rmsd_bonds	skos:exactMatch		nsls2:RMSD_bonds		skos:exactMatch	http://w3id.org/lambda/									
 lambda:rmsd_bonds	workflowRun__rmsd_bonds	skos:exactMatch		mmCIF:_refine.pdbx_ls_sigma_F		skos:exactMatch	http://w3id.org/lambda/									
 lambda:rwork	workflowRun__rwork	skos:exactMatch		mmCIF:_refine.ls_R_factor_R_work		skos:exactMatch	http://w3id.org/lambda/									
+lambda:software_name	workflowRun__software_name	skos:relatedMatch		IHMCIF:_ihm_modeling_protocol_details.software_id		skos:relatedMatch	http://w3id.org/lambda/									
 lambda:space_group	workflowRun__space_group	skos:exactMatch		nsls2:Space_Group		skos:exactMatch	http://w3id.org/lambda/									
 lambda:space_group	workflowRun__space_group	skos:exactMatch		mmCIF:_symmetry.space_group_name_H-M		skos:exactMatch	http://w3id.org/lambda/									
 lambda:space_group	workflowRun__space_group	skos:exactMatch		ispyb:AutoProcScaling.spaceGroup		skos:exactMatch	http://w3id.org/lambda/									
@@ -269,6 +284,7 @@ lambda:unit_cell_gamma	workflowRun__unit_cell_gamma	skos:exactMatch		nsls2:Unit_
 lambda:unit_cell_gamma	workflowRun__unit_cell_gamma	skos:exactMatch		mmCIF:_cell.angle_gamma		skos:exactMatch	http://w3id.org/lambda/									
 lambda:wilson_b_factor	workflowRun__wilson_b_factor	skos:exactMatch		nsls2:Wilson_B		skos:exactMatch	http://w3id.org/lambda/									
 lambda:wilson_b_factor	workflowRun__wilson_b_factor	skos:exactMatch		mmCIF:_reflns.B_iso_Wilson_estimate		skos:exactMatch	http://w3id.org/lambda/									
+lambda:workflow_type	workflowRun__workflow_type	skos:relatedMatch		IHMCIF:_ihm_modeling_protocol_details.step_method		skos:relatedMatch	http://w3id.org/lambda/									
 lambda:detector_manufacturer	xRayInstrument__detector_manufacturer	skos:exactMatch		mmCIF:_diffrn_detector.detector		skos:exactMatch	http://w3id.org/lambda/									
 lambda:detector_model	xRayInstrument__detector_model	skos:exactMatch		mmCIF:_diffrn_detector.pdbx_detector_model		skos:exactMatch	http://w3id.org/lambda/									
 lambda:detector_technology	xRayInstrument__detector_technology	skos:exactMatch		nsls2:Detector		skos:exactMatch	http://w3id.org/lambda/									
@@ -282,3 +298,36 @@ lambda:loop_size	xRayPreparation__loop_size	skos:exactMatch		nsls2:Loop_Size		sk
 lambda:mounting_method	xRayPreparation__mounting_method	skos:exactMatch		nsls2:Mount_Type		skos:exactMatch	http://w3id.org/lambda/									
 lambda:mounting_temperature	xRayPreparation__mounting_temperature	skos:exactMatch		nsls2:Temperature		skos:exactMatch	http://w3id.org/lambda/									
 lambda:temperature_c	xRayPreparation__temperature_c	skos:exactMatch		mmCIF:_exptl_crystal_grow.temp		skos:exactMatch	http://w3id.org/lambda/									
+lambda:DataFile	DataFile	skos:relatedMatch		IHMCIF:_ihm_dataset_list		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:DataFile	DataFile	skos:relatedMatch		IHMCIF:_ihm_dataset_external_reference		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:DataFile	DataFile	skos:closeMatch		IHMCIF:_ihm_external_files		skos:closeMatch	http://w3id.org/lambda/									
+lambda:Dataset	Dataset	skos:relatedMatch		IHMCIF:_ihm_entry_collection		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Dataset	Dataset	skos:relatedMatch		IHMCIF:_ihm_dataset_group		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:ExperimentRun	ExperimentRun	skos:relatedMatch		IHMCIF:_ihm_dataset_list		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:ExperimentRun	ExperimentRun	skos:relatedMatch		IHMCIF:_ihm_dataset_group		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Image3D	Image3D	skos:relatedMatch		IHMCIF:_ihm_3dem_restraint		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Image3D	Image3D	skos:relatedMatch		IHMCIF:_ihm_localization_density_files		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:MolecularComposition	MolecularComposition	skos:relatedMatch		IHMCIF:_ihm_entity_poly_segment		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:MolecularComposition	MolecularComposition	skos:relatedMatch		IHMCIF:_ihm_struct_assembly_details		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:QualityMetrics	QualityMetrics	skos:relatedMatch		IHMCIF:_ihm_ensemble_info		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:QualityMetrics	QualityMetrics	skos:relatedMatch		IHMCIF:_ihm_sas_restraint		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:QualityMetrics	QualityMetrics	skos:relatedMatch		IHMCIF:_ihm_3dem_restraint		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:RefinementParameters	RefinementParameters	skos:relatedMatch		IHMCIF:_ihm_model_representation		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:RefinementParameters	RefinementParameters	skos:relatedMatch		IHMCIF:_ihm_model_representation_details		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:RefinementParameters	RefinementParameters	skos:relatedMatch		IHMCIF:_ihm_model_list		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:RefinementParameters	RefinementParameters	skos:relatedMatch		IHMCIF:_ihm_ensemble_info		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Sample	Sample	skos:relatedMatch		IHMCIF:_ihm_struct_assembly		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Sample	Sample	skos:relatedMatch		IHMCIF:_ihm_struct_assembly_details		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Sample	Sample	skos:relatedMatch		IHMCIF:_ihm_entity_poly_segment		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:SAXSPreparation	SAXSPreparation	skos:relatedMatch		IHMCIF:_ihm_sas_restraint		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Study	Study	skos:relatedMatch		IHMCIF:_ihm_entry_collection		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:Study	Study	skos:relatedMatch		IHMCIF:_ihm_entry_collection_mapping		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowExperimentAssociation	WorkflowExperimentAssociation	skos:relatedMatch		IHMCIF:_ihm_modeling_protocol_details		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowInputAssociation	WorkflowInputAssociation	skos:relatedMatch		IHMCIF:_ihm_dataset_group_link		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowInputAssociation	WorkflowInputAssociation	skos:relatedMatch		IHMCIF:_ihm_dataset_list		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowOutputAssociation	WorkflowOutputAssociation	skos:relatedMatch		IHMCIF:_ihm_model_group_link		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowOutputAssociation	WorkflowOutputAssociation	skos:relatedMatch		IHMCIF:_ihm_model_list		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowOutputAssociation	WorkflowOutputAssociation	skos:relatedMatch		IHMCIF:_ihm_ensemble_info		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowRun	WorkflowRun	skos:relatedMatch		IHMCIF:_ihm_modeling_post_process		skos:relatedMatch	http://w3id.org/lambda/									
+lambda:WorkflowRun	WorkflowRun	skos:closeMatch		IHMCIF:_ihm_modeling_protocol		skos:closeMatch	http://w3id.org/lambda/									
+lambda:WorkflowRun	WorkflowRun	skos:closeMatch		IHMCIF:_ihm_modeling_protocol_details		skos:closeMatch	http://w3id.org/lambda/									

--- a/docs/background/README.md
+++ b/docs/background/README.md
@@ -18,6 +18,12 @@ Comprehensive comparison with mmCIF (macromolecular Crystallographic Information
 - Workflow integration strategies
 - Recommendations for using both standards together
 
+### [IHMCIF Alignment](ihmcif-alignment.md)
+Focused alignment with the IHMCIF/PDB-IHM extension for integrative and hybrid structural models. This document covers:
+- Why Lambda should align to IHMCIF rather than import it
+- Conservative mapping strategy for existing Lambda concepts
+- Gaps to track for future PDB-IHM export support
+
 ### [EMDB Alignment](emdb.md)
 Analysis of integration with the Electron Microscopy Data Bank for 3D reconstructions. This document explores:
 - Mapping between EMDB XML schema and lambda-ber-schema
@@ -52,6 +58,7 @@ All analyzed standards are complementary to lambda-ber-schema rather than compet
 
 - **NeXus** excels at facility-level raw data capture with HDF5 storage
 - **mmCIF** is the definitive standard for atomic structure representation and PDB deposition
+- **IHMCIF** captures deposition-grade integrative and hybrid model semantics that Lambda should map to, not absorb wholesale
 - **EMDB** provides the archive for 3D EM reconstructions with comprehensive validation
 - **EMPIAR** manages petabyte-scale raw microscopy data with expanding modality support
 - **DIALS** delivers modern crystallography data processing with extensible architecture

--- a/docs/background/ihmcif-alignment.md
+++ b/docs/background/ihmcif-alignment.md
@@ -1,0 +1,102 @@
+# lambda-ber-schema and IHMCIF Alignment
+
+## Summary
+
+lambda-ber-schema should align to IHMCIF, not import it as a native submodel.
+
+IHMCIF is the PDB-IHM extension of PDBx/mmCIF for archived integrative and hybrid structural models. It is strongest where the final scientific product is a deposited integrative model: model representations, structural assemblies, model groups, ensembles, spatial restraints, starting models, and multi-state schemes.
+
+lambda-ber-schema has a broader upstream scope. It tracks samples, preparations, instruments, experiment runs, workflow runs, raw and intermediate files, multimodal imaging, and facility or laboratory provenance. Many Lambda records may never become a PDB-IHM deposition.
+
+## Current Dictionary Scale
+
+The IHMCIF extension dictionary inspected for this alignment was `mmcif_ihm_ext.dic` version `1.28`, last updated `2025-03-24`, from the wwPDB dictionary site:
+
+- https://mmcif.wwpdb.org/dictionaries/mmcif_ihm.dic/Index/
+- https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_ihm_ext.dic
+
+The extension dictionary contains roughly:
+
+- 83 active IHM categories
+- 622 IHM data items
+- additional extension items on existing PDBx/mmCIF categories, such as `_atom_site.ihm_model_id`
+
+That size is large enough that directly importing IHMCIF would reshape Lambda around an archive and deposition format. The better approach is to keep Lambda generic and add mappings where concepts correspond.
+
+## Design Decision
+
+Do not import IHMCIF categories as first-class Lambda tables by default.
+
+Instead:
+
+- Keep Lambda concepts generic and workflow-centered.
+- Use IHMCIF as an external mapping target.
+- Prefer `close_mappings` and `related_mappings` over `exact_mappings` unless a slot has the same semantics as an IHMCIF item.
+- Add new Lambda classes only when a concept is broadly useful outside PDB-IHM deposition.
+
+This keeps Lambda useful for local data management, multimodal BER experiments, and pre-deposition provenance while still allowing export to IHMCIF/PDB-IHM when appropriate.
+
+## Conceptual Alignment
+
+| IHMCIF area | Lambda alignment | Mapping strength | Notes |
+| --- | --- | --- | --- |
+| `_ihm_entry_collection`, `_ihm_dataset_group` | `Dataset`, `Study` | Related | Lambda groups all local research records; IHMCIF groups deposited entries or evidence datasets. |
+| `_ihm_dataset_list` | `ExperimentRun`, `DataFile`, workflow input associations | Related/close | Lambda separates runs, files, and workflow links rather than using IHMCIF dataset records directly. |
+| `_ihm_external_files`, `_ihm_external_reference_info` | `DataFile` | Close | Lambda file metadata is broader and can include local paths, storage URIs, checksums, and non-deposition files. |
+| `_ihm_modeling_protocol`, `_ihm_modeling_protocol_details` | `WorkflowRun` | Close | Lambda workflow runs map well conceptually, but IHMCIF has deposition-specific protocol steps and references. |
+| `_ihm_struct_assembly`, `_ihm_struct_assembly_details`, `_ihm_entity_poly_segment` | `Sample`, `MolecularComposition` | Related | Lambda samples are physical/biological inputs; IHMCIF assemblies are modeled structural components. |
+| `_ihm_model_representation`, `_ihm_model_list`, `_ihm_model_group`, `_ihm_ensemble_info` | `WorkflowRun`, `RefinementParameters`, `QualityMetrics`, `DataFile` | Related | Lambda can point to model outputs, but does not currently encode IHMCIF's full representation and ensemble model. |
+| `_ihm_3dem_restraint`, `_ihm_sas_restraint` | `Image3D`, `SAXSPreparation`, `QualityMetrics`, `DataFile` | Related | Lambda captures source experiments and files; IHMCIF captures how those data constrain a deposited model. |
+| Crosslink, HDX, EPR, geometric, predicted-contact, and probe restraints | No direct generic class yet | Gap | A future generic `Evidence` or `Restraint` concept could align here without importing all IHMCIF categories. |
+| Multi-state schemes, ordered ensembles, kinetics | Limited or absent | Gap | These should remain future work unless Lambda needs broad dynamic or multi-state modeling support. |
+
+## Schema Changes
+
+The schema now includes an `IHMCIF` prefix:
+
+```yaml
+IHMCIF: https://mmcif.wwpdb.org/dictionaries/mmcif_ihm_ext.dic/Items/
+```
+
+Mappings were added only to existing Lambda concepts:
+
+- `Dataset` and `Study` relate to IHMCIF entry collections and dataset groups.
+- `Sample` and `MolecularComposition` relate to structural assemblies and polymer segments.
+- `ExperimentRun` relates to IHMCIF dataset records.
+- `WorkflowRun` closely maps to IHMCIF modeling protocol categories.
+- `DataFile` closely maps to IHMCIF external file records and relates to dataset references.
+- `Image3D`, `SAXSPreparation`, and `QualityMetrics` relate to 3DEM and SAS restraint categories.
+- Workflow association tables relate to IHMCIF dataset and model group link categories.
+
+The mappings are intentionally conservative. Lambda should not claim `exact_mappings` for broad concepts that only partially overlap IHMCIF deposition categories.
+
+## Gaps Worth Tracking
+
+If PDB-IHM export becomes a requirement, the highest-value generic additions would be:
+
+1. `ExternalDataset`: a dataset or evidence object distinct from a file.
+2. `Evidence`: a generic record connecting an experiment, data file, measurement type, and interpretation.
+3. `Restraint`: a generic modeling constraint with type, source data, target features, and confidence.
+4. `ModelRepresentation`: a generic description of atomic, coarse-grained, mixed, or ensemble model outputs.
+5. `ModelGroup` or `Ensemble`: a generic grouping of output models with representative or clustering metadata.
+
+These should be designed for Lambda first, then mapped to IHMCIF. They should not copy the full IHMCIF category tables unless deposition-grade PDB-IHM support becomes a core objective.
+
+## Export Implications
+
+A future Lambda-to-IHMCIF exporter should:
+
+- use Lambda records as upstream provenance;
+- use `DataFile` and workflow associations to populate IHMCIF datasets and external files;
+- use `WorkflowRun` records to populate modeling protocol categories;
+- map only explicit generic evidence/restraint/model representation records into IHMCIF restraints and model categories;
+- use `python-ihm` or a comparable library rather than hand-writing CIF text.
+
+Without additional generic evidence and model-representation classes, Lambda can support partial IHMCIF metadata export, but not complete PDB-IHM deposition.
+
+## References
+
+- PDB-IHM data system: https://data.pdb-ihm.org/
+- IHMCIF dictionary index: https://mmcif.wwpdb.org/dictionaries/mmcif_ihm.dic/Index/
+- IHMCIF extension dictionary: https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_ihm_ext.dic
+- IHMCIF GitHub repository: https://github.com/ihmwg/IHMCIF

--- a/docs/background/index.md
+++ b/docs/background/index.md
@@ -18,6 +18,12 @@ Comprehensive comparison with mmCIF (macromolecular Crystallographic Information
 - Workflow integration strategies
 - Recommendations for using both standards together
 
+### [IHMCIF Alignment](ihmcif-alignment.md)
+Focused alignment with the IHMCIF/PDB-IHM extension for integrative and hybrid structural models. This document covers:
+- Why Lambda should align to IHMCIF rather than import it
+- Conservative mapping strategy for existing Lambda concepts
+- Gaps to track for future PDB-IHM export support
+
 ### [EMDB Alignment](emdb.md)
 Analysis of integration with the Electron Microscopy Data Bank for 3D reconstructions. This document explores:
 - Mapping between EMDB XML schema and lambda-ber-schema
@@ -59,6 +65,7 @@ All analyzed standards are complementary to lambda-ber-schema rather than compet
 
 - **NeXus** excels at facility-level raw data capture with HDF5 storage
 - **mmCIF** is the definitive standard for atomic structure representation and PDB deposition
+- **IHMCIF** captures deposition-grade integrative and hybrid model semantics that Lambda should map to, not absorb wholesale
 - **OneDep** is the wwPDB deposition portal where metadata from lambda-ber-schema ultimately feeds
 - **EMDB** provides the archive for 3D EM reconstructions with comprehensive validation
 - **EMPIAR** manages petabyte-scale raw microscopy data with expanding modality support

--- a/src/lambda_ber_schema/schema/lambda_ber_schema.yaml
+++ b/src/lambda_ber_schema/schema/lambda_ber_schema.yaml
@@ -124,6 +124,7 @@ prefixes:
   nsls2: https://github.com/NSLS2/BER-LAMBDA/
   imgCIF: https://github.com/dials/cbflib/blob/main/doc/cif_img_1.8.6.dic#
   mmCIF: http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/
+  IHMCIF: https://mmcif.wwpdb.org/dictionaries/mmcif_ihm_ext.dic/Items/
   ROR: https://ror.org/
   wikidata: http://www.wikidata.org/entity/
   CHMO: http://purl.obolibrary.org/obo/CHMO_
@@ -176,6 +177,9 @@ classes:
     description: >-
       Root container holding flat entity collections and association tables.
       Follows relational database design patterns for structural biology data.
+    related_mappings:
+      - IHMCIF:_ihm_entry_collection
+      - IHMCIF:_ihm_dataset_group
     attributes:
       keywords:
         description: "Keywords or tags describing the dataset for search and categorization"
@@ -276,6 +280,9 @@ classes:
     description: >-
       A logical grouping of related experiments investigating a research question.
       In the relational model, Study is lightweight - all relationships are via association tables.
+    related_mappings:
+      - IHMCIF:_ihm_entry_collection
+      - IHMCIF:_ihm_entry_collection_mapping
     attributes:
       keywords:
         description: "Keywords or tags describing the study for search and categorization"
@@ -286,6 +293,10 @@ classes:
   Sample:
     is_a: NamedThing
     description: "A biological sample used in structural biology experiments"
+    related_mappings:
+      - IHMCIF:_ihm_struct_assembly
+      - IHMCIF:_ihm_struct_assembly_details
+      - IHMCIF:_ihm_entity_poly_segment
     attributes:
       sample_code:
         description: "Human-friendly laboratory identifier or facility code for the sample (e.g., 'ALS-12.3.1-SAMPLE-001', 'LAB-PROT-2024-01'). Used for local reference and tracking within laboratory workflows."
@@ -1058,6 +1069,9 @@ classes:
   ExperimentRun:
     is_a: NamedThing
     description: "An experimental data collection session"
+    related_mappings:
+      - IHMCIF:_ihm_dataset_list
+      - IHMCIF:_ihm_dataset_group
     attributes:
       experiment_code:
         description: "Human-friendly laboratory or facility identifier for the experiment (e.g., 'SIBYLS-2024-02-01-hetBGL', 'CRYOEM-RUN-240815-001'). Used for local tracking and cross-referencing within laboratory systems."
@@ -1073,6 +1087,8 @@ classes:
         description: "Technique used for data collection"
         range: TechniqueEnum
         required: true
+        related_mappings:
+          - IHMCIF:_ihm_dataset_list.data_type
       experimental_method:
         description: "Specific experimental method for structure determination (particularly for diffraction techniques)"
         range: ExperimentalMethodEnum
@@ -1412,6 +1428,11 @@ classes:
   WorkflowRun:
     is_a: NamedThing
     description: "A computational processing workflow execution"
+    close_mappings:
+      - IHMCIF:_ihm_modeling_protocol
+      - IHMCIF:_ihm_modeling_protocol_details
+    related_mappings:
+      - IHMCIF:_ihm_modeling_post_process
     attributes:
       workflow_code:
         description: "Human-friendly identifier for the computational workflow run (e.g., 'MOTION-CORR-RUN-001', 'RELION-REFINE-240815'). Used for tracking processing pipelines and computational provenance."
@@ -1420,6 +1441,8 @@ classes:
         description: "Type of processing workflow"
         range: WorkflowTypeEnum
         required: true
+        related_mappings:
+          - IHMCIF:_ihm_modeling_protocol_details.step_method
       # Relationships removed - use WorkflowExperimentAssociation
       processing_level:
         description: "Processing level (0=raw, 1=corrected, 2=derived, 3=model)"
@@ -1428,14 +1451,21 @@ classes:
       software_name:
         description: "Software used for processing"
         required: true
+        related_mappings:
+          - IHMCIF:_ihm_modeling_protocol_details.software_id
       software_version:
         description: "Software version"
       additional_software:
         description: "Additional software used in pipeline"
       processing_parameters:
         description: "Parameters used in processing"
+        related_mappings:
+          - IHMCIF:_ihm_modeling_protocol_details.description
       parameters_file_path:
         description: "Path to parameters file or text of key parameters"
+        related_mappings:
+          - IHMCIF:_ihm_modeling_protocol_details.script_file_id
+          - IHMCIF:_ihm_external_files.file_path
       # Crystallographic processing modules
       indexer_module:
         description: "Indexing module used (e.g., MOSFLM, XDS)"
@@ -1704,20 +1734,31 @@ classes:
   DataFile:
     is_a: NamedThing
     description: "A data file generated or used in the study"
+    close_mappings:
+      - IHMCIF:_ihm_external_files
+    related_mappings:
+      - IHMCIF:_ihm_dataset_list
+      - IHMCIF:_ihm_dataset_external_reference
     attributes:
       file_name:
         description: "Name of the file"
         required: true
       file_path:
         description: "Path to the file"
+        close_mappings:
+          - IHMCIF:_ihm_external_files.file_path
       file_format:
         description: "File format"
         range: FileFormatEnum
         required: true
+        close_mappings:
+          - IHMCIF:_ihm_external_files.file_format
       file_size_bytes:
         description: "File size in bytes"
         range: QuantityValue
         inlined: true
+        close_mappings:
+          - IHMCIF:_ihm_external_files.file_size_bytes
       checksum:
         description: "SHA-256 checksum for data integrity"
       creation_date:
@@ -1726,16 +1767,25 @@ classes:
       data_type:
         description: "Type of data in the file"
         range: DataTypeEnum
+        close_mappings:
+          - IHMCIF:_ihm_dataset_list.data_type
       # Additional PNNL file metadata
       storage_uri:
         description: "Storage URI (S3, Globus, etc.)"
         range: string
+        related_mappings:
+          - IHMCIF:_ihm_external_reference_info.associated_url
+          - IHMCIF:_ihm_external_files.file_path
       related_entity:
         description: "ID of the entity that owns this file"
         range: string
+        related_mappings:
+          - IHMCIF:_ihm_dataset_list.id
       file_role:
         description: "Role of the file (raw, intermediate, final, diagnostic, metadata)"
         range: string
+        related_mappings:
+          - IHMCIF:_ihm_external_files.content_type
 
   Image:
     is_a: NamedThing
@@ -1784,6 +1834,9 @@ classes:
   Image3D:
     is_a: Image
     description: "A 3D volume or tomogram"
+    related_mappings:
+      - IHMCIF:_ihm_3dem_restraint
+      - IHMCIF:_ihm_localization_density_files
     attributes:
       dimensions_z:
         description: "Image depth, typically specified in pixels or slices. Data providers may specify alternative units by including the unit in the QuantityValue."
@@ -2054,6 +2107,9 @@ classes:
   MolecularComposition:
     is_a: AttributeGroup
     description: "Molecular composition of a sample"
+    related_mappings:
+      - IHMCIF:_ihm_entity_poly_segment
+      - IHMCIF:_ihm_struct_assembly_details
     attributes:
       sequences:
         description: "Amino acid or nucleotide sequences"
@@ -2364,6 +2420,8 @@ classes:
   SAXSPreparation:
     is_a: TechniqueSpecificPreparation
     description: "SAXS/WAXS specific preparation"
+    related_mappings:
+      - IHMCIF:_ihm_sas_restraint
     attributes:
       concentration_series:
         description: "Concentration values for series measurements"
@@ -2579,6 +2637,10 @@ classes:
   QualityMetrics:
     is_a: AttributeGroup
     description: "Quality metrics for experiments"
+    related_mappings:
+      - IHMCIF:_ihm_ensemble_info
+      - IHMCIF:_ihm_sas_restraint
+      - IHMCIF:_ihm_3dem_restraint
     attributes:
       # General metrics
       resolution:
@@ -2743,6 +2805,8 @@ classes:
         description: "Radius of gyration, typically specified in Angstroms. Data providers may specify alternative units by including the unit in the QuantityValue."
         range: QuantityValue
         inlined: true
+        close_mappings:
+          - IHMCIF:_ihm_sas_restraint.radius_of_gyration
       # Legacy/deprecated
       r_factor:
         description: "R-factor for crystallography (deprecated, use r_work)"
@@ -2871,6 +2935,11 @@ classes:
   RefinementParameters:
     is_a: AttributeGroup
     description: "Parameters specific to 3D refinement workflows"
+    related_mappings:
+      - IHMCIF:_ihm_model_representation
+      - IHMCIF:_ihm_model_representation_details
+      - IHMCIF:_ihm_model_list
+      - IHMCIF:_ihm_ensemble_info
     attributes:
       symmetry:
         description: "Symmetry applied (C1, Cn, Dn, T, O, I)"
@@ -3002,6 +3071,8 @@ classes:
 
   WorkflowExperimentAssociation:
     description: "M:N link between WorkflowRun and source ExperimentRuns"
+    related_mappings:
+      - IHMCIF:_ihm_modeling_protocol_details
     attributes:
       workflow_id:
         description: "Reference to the workflow run"
@@ -3014,6 +3085,9 @@ classes:
 
   WorkflowInputAssociation:
     description: "Links input DataFiles to WorkflowRun"
+    related_mappings:
+      - IHMCIF:_ihm_dataset_group_link
+      - IHMCIF:_ihm_dataset_list
     attributes:
       workflow_id:
         description: "Reference to the workflow run"
@@ -3029,6 +3103,10 @@ classes:
 
   WorkflowOutputAssociation:
     description: "Links output DataFiles to WorkflowRun"
+    related_mappings:
+      - IHMCIF:_ihm_model_group_link
+      - IHMCIF:_ihm_model_list
+      - IHMCIF:_ihm_ensemble_info
     attributes:
       workflow_id:
         description: "Reference to the workflow run"


### PR DESCRIPTION
## Summary

Adds a lightweight IHMCIF alignment for Lambda without importing IHMCIF as a native submodel.

- Adds an `IHMCIF` prefix and conservative `close_mappings` / `related_mappings` to existing generic Lambda classes and slots.
- Adds `docs/background/ihmcif-alignment.md` documenting the align-not-import strategy, conceptual coverage, gaps, and export implications.
- Updates background indexes and regenerates the tracked SSSOM mapping export.

## Validation

- `python3` YAML parse of `src/lambda_ber_schema/schema/lambda_ber_schema.yaml` passed.
- `uv run gen-sssom src/lambda_ber_schema/schema/lambda_ber_schema.yaml -o assets/sssom/lambda_ber_schema.sssom.tsv` passed.
- `uv run linkml-lint src/lambda_ber_schema/schema/lambda_ber_schema.yaml` ran, but exits nonzero on existing enum naming and canonical prefix warnings.
- `git diff --check` flags generated SSSOM rows because empty trailing TSV columns are emitted as trailing tabs.

## Notes

The PR intentionally does not add IHMCIF category tables to Lambda. It maps Lambda's broader concepts to IHMCIF for interoperability and leaves deposition-grade PDB-IHM export as future work.
