### PR TITLE
Pin current model IDs in Claude CI workflows (#111)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,8 +43,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin an explicit current model. The action's built-in default
+          # (claude-sonnet-4-20250514) retired 2026-06-15 and now 404s.
+          # Bump to "claude-opus-4-8" for deeper reviews.
+          model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude-ontology-review.yml
+++ b/.github/workflows/claude-ontology-review.yml
@@ -39,8 +39,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (commenting defaults to Claude Sonnet 4)
-          model: "claude-opus-4-1-20250805"
+          # Pin an explicit current model (claude-opus-4-1-20250805 is deprecated,
+          # retires 2026-08-05). Opus is used here for thorough ontology review.
+          model: "claude-opus-4-8"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,8 +66,10 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin an explicit current model. The action's built-in default
+          # (claude-sonnet-4-20250514) retired 2026-06-15 and now 404s.
+          # Bump to "claude-opus-4-8" for harder tasks.
+          model: "claude-sonnet-4-6"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
Closes #111.

## Root cause

The PR review action failed with a **404 not_found_error** for `model: claude-sonnet-4-20250514`. That model string is the **built-in default** of `anthropics/claude-code-action@beta` — the workflow didn't pin a model, so it fell back to the default, and that model **retired 2026-06-15** (we're past that date). A retired model ID returns 404, which surfaced as the failed `Run Claude Code Review` step on PR #110.

## Fix

Pin explicit, current model IDs so the workflows no longer depend on a moving (and now-dead) default:

| Workflow | Before | After |
|---|---|---|
| `claude-code-review.yml` (the failing review action) | _(unset → dead default)_ | `claude-sonnet-4-6` |
| `claude.yml` (`@claude` responder) | _(unset → dead default)_ | `claude-sonnet-4-6` |
| `claude-ontology-review.yml` | `claude-opus-4-1-20250805` (deprecated, retires 2026-08-05) | `claude-opus-4-8` |

`dragon-ai.yml` is unaffected — it invokes the `claude` CLI with no `--model` flag, so it uses the current CLI default.

Sonnet 4.6 is a sensible cost/quality fit for routine PR review (it matches the action's prior sonnet-tier default); bump any of these to `claude-opus-4-8` for deeper reviews. The pinned IDs were confirmed against the current model catalog, and all three workflows validate as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)